### PR TITLE
Extend template parts

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -15,7 +15,7 @@
 
   <?php
   /**
-   * Fires immediately before the footer element markup.
+   * Fires before the footer element markup.
    *
    * @since 1.0.0
    */
@@ -39,7 +39,7 @@
 
   <?php
   /**
-   * Fires immediately after the footer element markup.
+   * Fires after the footer element markup.
    *
    * @since 1.0.0
    */
@@ -50,7 +50,7 @@
 
 <?php
 /**
- * Fires immediately before wp_footer(), before the closing body tag.
+ * Fires before wp_footer() and the closing body tag.
  *
  * @since 1.0.0
  */

--- a/footer.php
+++ b/footer.php
@@ -15,7 +15,7 @@
 
   <?php
   /**
-   * Fires immediately before the footer element opening markup.
+   * Fires immediately before the footer element markup.
    *
    * @since 1.0.0
    */
@@ -39,7 +39,7 @@
 
   <?php
   /**
-   * Fires immediately after the footer element closing markup.
+   * Fires immediately after the footer element markup.
    *
    * @since 1.0.0
    */
@@ -50,7 +50,7 @@
 
 <?php
 /**
- * Fires immediately before wp_footer(), before the body element closing markup.
+ * Fires immediately before wp_footer(), before the closing body tag.
  *
  * @since 1.0.0
  */

--- a/header.php
+++ b/header.php
@@ -24,7 +24,7 @@
 
 <?php
 /**
- * Fires immediately after the body element opening markup.
+ * Fires immediately after the opening body tag.
  *
  * @since 1.0.0
  */

--- a/header.php
+++ b/header.php
@@ -24,7 +24,7 @@
 
 <?php
 /**
- * Fires immediately after the opening body tag.
+ * Fires after the opening body tag.
  *
  * @since 1.0.0
  */
@@ -32,99 +32,53 @@ do_action( 'emma_before' );
 ?>
 
 <div id="page" class="site">
-  <a class="skip-link screen-reader-shortcut" href="#content"><?php esc_html_e( 'Skip to content', 'emma' ); ?></a>
+
+  <?php
+  /**
+   * Fires before the site-header markup.
+   *
+   * @since 1.0.0
+   */
+  do_action( 'emma_before_header' );
+  ?>
 
 	<header id="masthead" class="site-header">
 
-    <?php get_template_part( 'template-parts/utility', 'bar' ); ?>
+    <?php
+    /**
+     * Fires inside the site-header markup before the opening wrap tag.
+     *
+     * This action is ideal for high visibility items such as alert bars,
+     * account information and global functionality that remains visible at all
+     * breakpoints (e.g. search, mini cart, login/logout links).
+     *
+     * @since 1.0.0
+     */
+    do_action( 'emma_header_bar' );
+    ?>
 
     <div class="wrap">
 
-      <?php if ( has_nav_menu( 'left' ) ) : ?>
-        <nav id="left-navigation" class="site-navigation left-navigation">
-
-          <?php
-          wp_nav_menu( array(
-            'theme_location'  => 'left',
-            'menu_id'         => 'left-menu',
-            'container_class' => 'menu-container',
-          ) );
-          ?>
-
-        </nav><!-- #left-navigation -->
-      <?php endif; ?>
-
-      <div class="site-branding">
-
-        <?php do_action( 'site_branding' ); ?>
-
-        <p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
-
-        <?php
-        $emma_description = get_bloginfo( 'description', 'display' );
-        if ( $emma_description || is_customize_preview() ) :
-          ?>
-          <p class="site-description"><?php echo $emma_description; ?></p>
-        <?php endif; ?>
-
-      </div><!-- .site-branding -->
-
-      <?php if ( has_nav_menu( 'right' ) ) : ?>
-        <nav id="right-navigation" class="site-navigation right-navigation">
-
-          <?php
-          wp_nav_menu( array(
-            'theme_location'  => 'right',
-            'menu_id'         => 'right-menu',
-            'container_class' => 'menu-container',
-          ) );
-          ?>
-
-        </nav><!-- #right-navigation -->
-      <?php endif; ?>
-
       <?php
-      if ( is_active_sidebar( 'header-widgets' ) ) {
-        ?>
-
-        <div id="header-widgets" class="header-widgets">
-
-          <?php dynamic_sidebar( 'header-widgets' ); ?>
-
-        </div>
-
-        <?php
-      }
+      /**
+       * Fires inside the site-header and wrap markup.
+       *
+       * @since 1.0.0
+       */
+      do_action( 'emma_header' );
       ?>
-
-      <div class="navigation-controls">
-        <a href="javascript:void(0);" id="menu-opener" class="menu-toggle menu-opener" aria-controls="menu-drawer" aria-expanded="false" title="<?php esc_html_e( 'Primary Menu', 'emma' ); ?>">
-          <span class="dashicons dashicons-menu-alt"></span>
-          <span class="screen-reader-text">Open Menu</span>
-        </a>
-      </div><!-- .navigation-controls -->
 
     </div><!-- .wrap -->
 
   </header><!-- #masthead -->
 
-  <div id="sticky-saver" class="sticky-saver"></div>
-
-  <?php if ( has_nav_menu( 'primary' ) ) : ?>
-      <nav id="main-navigation" class="site-navigation main-navigation">
-        <div class="wrap">
-
-          <?php
-          wp_nav_menu( array(
-            'theme_location'  => 'primary',
-            'menu_id'         => 'primary-menu',
-            'container_class' => 'menu-container',
-          ) );
-          ?>
-
-        </div><!-- .wrap -->
-
-      </nav><!-- #main-navigation -->
-    <?php endif; ?>
+  <?php
+  /**
+   * Fires after the site-header markup.
+   *
+   * @since 1.0.0
+   */
+  do_action( 'emma_after_header' );
+  ?>
 
 	<div id="content" class="site-content">

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -219,11 +219,3 @@ function emma_save_layout_options_postdata( $post_id ) {
 	}
 }
 add_action('save_post', 'emma_save_layout_options_postdata');
-
-/**
- * Site Branding action
- */
-function emma_site_branding() {
-	the_custom_logo();
-}
-add_action( 'site_branding', 'emma_site_branding', 10 );

--- a/inc/template-parts.php
+++ b/inc/template-parts.php
@@ -23,6 +23,14 @@ function emma_post_thumbnail_template() {
 add_action( 'emma_after_entry_header', 'emma_post_thumbnail_template' );
 
 /**
+ * Gets the entry header template part.
+ */
+function emma_entry_header_template() {
+  get_template_part( 'template-parts/entry', 'header' );
+}
+add_action( 'emma_before_entry_content', 'emma_entry_header_template' );
+
+/**
  * Gets the entry footer template part.
  */
 function emma_entry_footer_template() {

--- a/inc/template-parts.php
+++ b/inc/template-parts.php
@@ -5,6 +5,66 @@
  * @package Emma
  */
 
+ /**
+ * Gets the skip link template part.
+ */
+function emma_skip_link_template() {
+	?>
+
+  <a class="skip-link screen-reader-shortcut" href="#content"><?php esc_html_e( 'Skip to content', 'emma' ); ?></a>
+
+	<?php
+}
+add_action( 'emma_before_header', 'emma_skip_link_template' );
+
+/**
+ * Gets the utility bar template part.
+ */
+function emma_utility_bar_template() {
+  get_template_part( 'template-parts/utility', 'bar' );
+}
+add_action( 'emma_header_bar', 'emma_utility_bar_template' );
+
+/**
+ * Gets the header inner template parts.
+ */
+function emma_header_inner_template() {
+  get_template_part( 'template-parts/navigation', 'left' );
+  get_template_part( 'template-parts/site', 'branding' );
+  get_template_part( 'template-parts/navigation', 'right' );
+  get_template_part( 'template-parts/header', 'widgets' );
+  get_template_part( 'template-parts/navigation', 'controls' );
+}
+add_action( 'emma_header', 'emma_header_inner_template' );
+
+/**
+ * Gets the site branding template part.
+ */
+function emma_site_branding_template() {
+	the_custom_logo();
+}
+add_action( 'emma_site_branding', 'emma_site_branding_template' );
+
+/**
+ * Gets the sticky saver template part.
+ */
+function emma_sticky_saver_template() {
+	?>
+
+	<div id="sticky-saver" class="sticky-saver"></div>
+
+	<?php
+}
+add_action( 'emma_after_header', 'emma_sticky_saver_template' );
+
+/**
+ * Gets the primary navigation template part.
+ */
+function emma_primary_navigation_template() {
+  get_template_part( 'template-parts/navigation', 'primary' );
+}
+add_action( 'emma_after_header', 'emma_primary_navigation_template' );
+
 /**
  * Gets the post thumbnail template part.
  */
@@ -22,7 +82,7 @@ function emma_entry_header_template() {
 add_action( 'emma_before_entry_content', 'emma_entry_header_template' );
 
 /**
- * Gets the entry header inner template part.
+ * Gets the entry header inner template parts.
  */
 function emma_entry_header_inner_template() {
   get_template_part( 'template-parts/post', 'title' );
@@ -47,7 +107,7 @@ function emma_entry_footer_template() {
 add_action( 'emma_after_entry_content', 'emma_entry_footer_template' );
 
 /**
- * Gets the entry footer inner template part.
+ * Gets the entry footer inner template parts.
  */
 function emma_entry_footer_inner_template() {
   get_template_part( 'template-parts/post', 'categories' );

--- a/inc/template-parts.php
+++ b/inc/template-parts.php
@@ -6,15 +6,6 @@
  */
 
 /**
- * Gets the post title template part.
- */
-function emma_post_title_template() {
-  get_template_part( 'template-parts/post', 'title' );
-  get_template_part( 'template-parts/entry', 'meta' );
-}
-add_action( 'emma_entry_header', 'emma_post_title_template' );
-
-/**
  * Gets the post thumbnail template part.
  */
 function emma_post_thumbnail_template() {
@@ -31,12 +22,39 @@ function emma_entry_header_template() {
 add_action( 'emma_before_entry_content', 'emma_entry_header_template' );
 
 /**
+ * Gets the entry header inner template part.
+ */
+function emma_entry_header_inner_template() {
+  get_template_part( 'template-parts/post', 'title' );
+  get_template_part( 'template-parts/entry', 'meta' );
+}
+add_action( 'emma_entry_header', 'emma_entry_header_inner_template' );
+
+/**
+ * Gets the entry content template part.
+ */
+function emma_entry_content_template() {
+  get_template_part( 'template-parts/entry', 'content' );
+}
+add_action( 'emma_entry_content', 'emma_entry_content_template' );
+
+/**
  * Gets the entry footer template part.
  */
 function emma_entry_footer_template() {
   get_template_part( 'template-parts/entry', 'footer' );
 }
 add_action( 'emma_after_entry_content', 'emma_entry_footer_template' );
+
+/**
+ * Gets the entry footer inner template part.
+ */
+function emma_entry_footer_inner_template() {
+  get_template_part( 'template-parts/post', 'categories' );
+  get_template_part( 'template-parts/post', 'tags' );
+  get_template_part( 'template-parts/post', 'comments' );
+}
+add_action( 'emma_entry_footer', 'emma_entry_footer_inner_template' );
 
  /**
  * Gets the footer widgets template part.
@@ -52,7 +70,7 @@ add_action( 'emma_before_footer', 'emma_footer_widgets_template' );
 function emma_footer_menu_template() {
   get_template_part( 'template-parts/footer', 'menu' );
 }
-add_action( 'emma_footer', 'emma_footer_menu_template', 10 );
+add_action( 'emma_footer', 'emma_footer_menu_template' );
 
 /**
  * Gets the site info template part.
@@ -60,7 +78,7 @@ add_action( 'emma_footer', 'emma_footer_menu_template', 10 );
 function emma_site_info_template() {
   get_template_part( 'template-parts/site', 'info' );
 }
-add_action( 'emma_footer', 'emma_site_info_template', 20 );
+add_action( 'emma_footer', 'emma_site_info_template' );
 
 /**
  * Gets the menu drawer template part.

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -11,42 +11,7 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
-  <?php
-  /**
-   * Fires immediately before the entry-header opening markup.
-   *
-   * @since 1.0.0
-   */
-  do_action( 'emma_before_entry_header' );
-
-  $hide_title = get_post_meta( $post->ID, 'hide_title', true );
-  if( empty( $hide_title ) ) { ?>
-
-    <header class="entry-header">
-      <div class="wrap">
-
-        <?php
-        /**
-         * Fires inside the entry-header and wrap markup.
-         *
-         * @since 1.0.0
-        */
-        do_action( 'emma_entry_header' );
-        ?>
-
-      </div><!-- .wrap -->
-    </header><!-- .entry-header -->
-
-  <?php } ?>
-
-  <?php
-  /**
-   * Fires immediately after the entry-header closing markup.
-   *
-   * @since 1.0.0
-   */
-  do_action( 'emma_after_entry_header' );
-  ?>
+  <?php do_action( 'emma_before_entry_content' ); ?>
 
 	<div class="entry-content">
 		<?php
@@ -71,4 +36,5 @@
 	</div><!-- .entry-content -->
 
   <?php do_action( 'emma_after_entry_content' ); ?>
+
 </article><!-- #post-<?php the_ID(); ?> -->

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -11,30 +11,35 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
-  <?php do_action( 'emma_before_entry_content' ); ?>
+	<?php
+	/**
+	 * Fires before the entry-content markup.
+	 *
+	 * @since 1.0.0
+	*/
+	do_action( 'emma_before_entry_content' );
+	?>
 
 	<div class="entry-content">
-		<?php
-		the_content( sprintf(
-			wp_kses(
-				/* translators: %s: Name of current post. Only visible to screen readers */
-				__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'emma' ),
-				array(
-					'span' => array(
-						'class' => array(),
-					),
-				)
-			),
-			get_the_title()
-		) );
 
-		wp_link_pages( array(
-			'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'emma' ),
-			'after'  => '</div>',
-		) );
+		<?php
+		/**
+		 * Fires inside the entry-content markup.
+		 *
+		 * @since 1.0.0
+		*/
+		do_action( 'emma_entry_content' );
 		?>
+
 	</div><!-- .entry-content -->
 
-  <?php do_action( 'emma_after_entry_content' ); ?>
+	<?php
+	/**
+	 * Fires after the entry-content markup.
+	 *
+	 * @since 1.0.0
+	*/
+	do_action( 'emma_after_entry_content' );
+	?>
 
 </article><!-- #post-<?php the_ID(); ?> -->

--- a/template-parts/entry-content.php
+++ b/template-parts/entry-content.php
@@ -1,0 +1,18 @@
+<?php
+the_content( sprintf(
+  wp_kses(
+    /* translators: %s: Name of current post. Only visible to screen readers */
+    __( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'emma' ),
+    array(
+      'span' => array(
+        'class' => array(),
+      ),
+    )
+  ),
+  get_the_title()
+) );
+
+wp_link_pages( array(
+  'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'emma' ),
+  'after'  => '</div>',
+) );

--- a/template-parts/entry-footer.php
+++ b/template-parts/entry-footer.php
@@ -2,7 +2,7 @@
 
   <?php
   /**
-   * Fires immediately before the entry-footer markup.
+   * Fires before the entry-footer markup.
    *
    * @since 1.0.0
    */
@@ -26,7 +26,7 @@
 
   <?php
   /**
-   * Fires immediately after the entry-footer markup.
+   * Fires after the entry-footer markup.
    *
    * @since 1.0.0
    */

--- a/template-parts/entry-footer.php
+++ b/template-parts/entry-footer.php
@@ -1,41 +1,36 @@
-<?php
-if ( 'post' === get_post_type() ) { ?>
+<?php if ( 'post' === get_post_type() ) { ?>
+
+  <?php
+  /**
+   * Fires immediately before the entry-footer opening markup.
+   *
+   * @since 1.0.0
+   */
+  do_action( 'emma_before_entry_footer' );
+  ?>
+
   <footer class="entry-footer">
     <div class="wrap">
+
       <?php
-      /* translators: used between list items, there is a space after the comma */
-      $categories_list = get_the_category_list( esc_html__( ', ', 'emma' ) );
-      if ( $categories_list ) {
-        /* translators: 1: list of categories. */
-        printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'emma' ) . '</span>', $categories_list ); // WPCS: XSS OK.
-      }
-
-      /* translators: used between list items, there is a space after the comma */
-      $tags_list = get_the_tag_list( '', esc_html_x( ', ', 'list item separator', 'emma' ) );
-      if ( $tags_list ) {
-        /* translators: 1: list of tags. */
-        printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'emma' ) . '</span>', $tags_list ); // WPCS: XSS OK.
-      }
-
-      if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
-        echo '<span class="comments-link">';
-        comments_popup_link(
-          sprintf(
-            wp_kses(
-              /* translators: %s: post title */
-              __( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'emma' ),
-              array(
-                'span' => array(
-                  'class' => array(),
-                ),
-              )
-            ),
-            get_the_title()
-          )
-        );
-        echo '</span>';
-      }
+      /**
+       * Fires inside the entry-footer and wrap markup.
+       *
+       * @since 1.0.0
+       */
+      do_action( 'emma_entry_footer' );
       ?>
+
     </div><!-- .wrap -->
   </footer><!-- .entry-footer -->
-<?php }
+
+  <?php
+  /**
+   * Fires immediately after the entry-footer closing markup.
+   *
+   * @since 1.0.0
+   */
+  do_action( 'emma_after_entry_footer' );
+  ?>
+
+<?php } ?>

--- a/template-parts/entry-footer.php
+++ b/template-parts/entry-footer.php
@@ -2,7 +2,7 @@
 
   <?php
   /**
-   * Fires immediately before the entry-footer opening markup.
+   * Fires immediately before the entry-footer markup.
    *
    * @since 1.0.0
    */
@@ -26,7 +26,7 @@
 
   <?php
   /**
-   * Fires immediately after the entry-footer closing markup.
+   * Fires immediately after the entry-footer markup.
    *
    * @since 1.0.0
    */

--- a/template-parts/entry-header.php
+++ b/template-parts/entry-header.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Fires immediately before the entry-header opening markup.
+ *
+ * @since 1.0.0
+ */
+do_action( 'emma_before_entry_header' );
+
+$hide_title = get_post_meta( $post->ID, 'hide_title', true );
+if( empty( $hide_title ) ) { ?>
+
+  <header class="entry-header">
+    <div class="wrap">
+
+      <?php
+      /**
+       * Fires inside the entry-header and wrap markup.
+       *
+       * @since 1.0.0
+      */
+      do_action( 'emma_entry_header' );
+      ?>
+
+    </div><!-- .wrap -->
+  </header><!-- .entry-header -->
+
+<?php } ?>
+
+<?php
+/**
+ * Fires immediately after the entry-header closing markup.
+ *
+ * @since 1.0.0
+ */
+do_action( 'emma_after_entry_header' );
+?>

--- a/template-parts/entry-header.php
+++ b/template-parts/entry-header.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Fires immediately before the entry-header markup.
+ * Fires before the entry-header markup.
  *
  * @since 1.0.0
  */
@@ -28,7 +28,7 @@ if( empty( $hide_title ) ) { ?>
 
 <?php
 /**
- * Fires immediately after the entry-header markup.
+ * Fires after the entry-header markup.
  *
  * @since 1.0.0
  */

--- a/template-parts/entry-header.php
+++ b/template-parts/entry-header.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Fires immediately before the entry-header opening markup.
+ * Fires immediately before the entry-header markup.
  *
  * @since 1.0.0
  */
@@ -28,7 +28,7 @@ if( empty( $hide_title ) ) { ?>
 
 <?php
 /**
- * Fires immediately after the entry-header closing markup.
+ * Fires immediately after the entry-header markup.
  *
  * @since 1.0.0
  */

--- a/template-parts/header-widgets.php
+++ b/template-parts/header-widgets.php
@@ -1,0 +1,13 @@
+<?php
+if ( is_active_sidebar( 'header-widgets' ) ) {
+  ?>
+
+  <div id="header-widgets" class="header-widgets">
+
+    <?php dynamic_sidebar( 'header-widgets' ); ?>
+
+  </div>
+
+  <?php
+}
+?>

--- a/template-parts/navigation-controls.php
+++ b/template-parts/navigation-controls.php
@@ -1,0 +1,12 @@
+<div class="navigation-controls">
+  <a href="javascript:void(0);"
+    id="menu-opener"
+    class="menu-toggle menu-opener"
+    aria-controls="menu-drawer"
+    aria-expanded="false"
+    title="<?php esc_html_e( 'Primary Menu', 'emma' ); ?>
+  ">
+    <span class="dashicons dashicons-menu-alt"></span>
+    <span class="screen-reader-text">Open Menu</span>
+  </a>
+</div><!-- .navigation-controls -->

--- a/template-parts/navigation-left.php
+++ b/template-parts/navigation-left.php
@@ -1,0 +1,13 @@
+<?php if ( has_nav_menu( 'left' ) ) : ?>
+  <nav id="left-navigation" class="site-navigation left-navigation">
+
+    <?php
+    wp_nav_menu( array(
+      'theme_location'  => 'left',
+      'menu_id'         => 'left-menu',
+      'container_class' => 'menu-container',
+    ) );
+    ?>
+
+  </nav><!-- #left-navigation -->
+<?php endif; ?>

--- a/template-parts/navigation-primary.php
+++ b/template-parts/navigation-primary.php
@@ -1,0 +1,16 @@
+<?php if ( has_nav_menu( 'primary' ) ) : ?>
+  <nav id="main-navigation" class="site-navigation main-navigation">
+    <div class="wrap">
+
+      <?php
+      wp_nav_menu( array(
+        'theme_location'  => 'primary',
+        'menu_id'         => 'primary-menu',
+        'container_class' => 'menu-container',
+      ) );
+      ?>
+
+    </div><!-- .wrap -->
+
+  </nav><!-- #main-navigation -->
+<?php endif; ?>

--- a/template-parts/navigation-right.php
+++ b/template-parts/navigation-right.php
@@ -1,0 +1,13 @@
+<?php if ( has_nav_menu( 'right' ) ) : ?>
+  <nav id="right-navigation" class="site-navigation right-navigation">
+
+    <?php
+    wp_nav_menu( array(
+      'theme_location'  => 'right',
+      'menu_id'         => 'right-menu',
+      'container_class' => 'menu-container',
+    ) );
+    ?>
+
+  </nav><!-- #right-navigation -->
+<?php endif; ?>

--- a/template-parts/post-categories.php
+++ b/template-parts/post-categories.php
@@ -1,0 +1,7 @@
+<?php
+/* translators: used between list items, there is a space after the comma */
+$categories_list = get_the_category_list( esc_html__( ', ', 'emma' ) );
+if ( $categories_list ) {
+  /* translators: 1: list of categories. */
+  printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'emma' ) . '</span>', $categories_list ); // WPCS: XSS OK.
+}

--- a/template-parts/post-comments.php
+++ b/template-parts/post-comments.php
@@ -1,0 +1,19 @@
+<?php
+if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
+  echo '<span class="comments-link">';
+  comments_popup_link(
+    sprintf(
+      wp_kses(
+        /* translators: %s: post title */
+        __( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'emma' ),
+        array(
+          'span' => array(
+            'class' => array(),
+          ),
+        )
+      ),
+      get_the_title()
+    )
+  );
+  echo '</span>';
+}

--- a/template-parts/post-tags.php
+++ b/template-parts/post-tags.php
@@ -1,0 +1,7 @@
+<?php
+/* translators: used between list items, there is a space after the comma */
+$tags_list = get_the_tag_list( '', esc_html_x( ', ', 'list item separator', 'emma' ) );
+if ( $tags_list ) {
+  /* translators: 1: list of tags. */
+  printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'emma' ) . '</span>', $tags_list ); // WPCS: XSS OK.
+}

--- a/template-parts/site-branding.php
+++ b/template-parts/site-branding.php
@@ -1,0 +1,24 @@
+<div class="site-branding">
+
+  <?php
+  /**
+   * Fires inside the site-branding markup.
+   *
+   * @since 1.0.0
+   */
+  do_action( 'emma_site_branding' );
+  ?>
+
+  <p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+
+  <?php
+  $emma_description = get_bloginfo( 'description', 'display' );
+
+  if ( $emma_description || is_customize_preview() ) :
+    ?>
+
+    <p class="site-description"><?php echo $emma_description; ?></p>
+
+  <?php endif; ?>
+
+</div><!-- .site-branding -->


### PR DESCRIPTION
Improves template override capabilities by breaking templates into smaller pieces, adding additional hooks and creating new `template-parts` for more concise overrides in any child theme.