### PR TITLE
removed bootstrap reboot from admin styles

### DIFF
--- a/src/sass/emma-admin.scss
+++ b/src/sass/emma-admin.scss
@@ -18,7 +18,6 @@
 --------------------------------------------------------------*/
 @import "vendor/bootstrap/_variables.scss";
 @import "vendor/bootstrap/_mixins.scss";
-//@import "vendor/bootstrap/_reboot.scss";
 
 /*--------------------------------------------------------------
 # Gutenberg

--- a/src/sass/emma-admin.scss
+++ b/src/sass/emma-admin.scss
@@ -18,7 +18,7 @@
 --------------------------------------------------------------*/
 @import "vendor/bootstrap/_variables.scss";
 @import "vendor/bootstrap/_mixins.scss";
-@import "vendor/bootstrap/_reboot.scss";
+//@import "vendor/bootstrap/_reboot.scss";
 
 /*--------------------------------------------------------------
 # Gutenberg


### PR DESCRIPTION
removed bootstrap reboot from styles being enqueued in the editor because it was causing some unexpected shenanigans