### PR TITLE
removed date link from archives

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -27,7 +27,7 @@ if ( ! function_exists( 'emma_posted_on' ) ) :
 		$posted_on = sprintf(
 			/* translators: %s: post date. */
 			esc_html_x( 'Posted on %s', 'post date', 'emma' ),
-			'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
+			$time_string
 		);
 
 		echo '<span class="posted-on">' . $posted_on . '</span>'; // WPCS: XSS OK.


### PR DESCRIPTION
The date link in the archive template was directing to the post rather than to a date archive. Going to a date archive for a single date didn't make much sense, but the permalink to the post was already in the post title directly above, so I just removed the link altogether.