### PR TITLE
fixed issue with layout options fields not retrieving values in certain circumstances

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -153,22 +153,23 @@ add_filter( 'body_class', 'emma_output_custom_body_classes' );
 /**
  * Layout options metabox content
  */
-function emma_layout_options_metabox_html( $post ) {
+function emma_layout_options_metabox_html( $post, $metabox ) {
 	// hide_title
 	$hide_title = get_post_meta( $post->ID, 'hide_title', true );
-	$hide_title_checked = $hide_title == 1 ? 'checked' : '';
 
 	// post_layout
 	$post_layout = get_post_meta( $post->ID, 'post_layout', true );
 
 	// feature_image_before_title
 	$featured_image_before_title = get_post_meta( $post->ID, 'featured_image_before_title', true );
+
+	wp_nonce_field( basename(__FILE__), 'layout_options_meta_box_nonce' );
 	?>
 
 	<div class="components-base-control">
 		<div class="components-base-control__field">
 			<span class="components-checkbox-control__input-container">
-				<input id="hide-title-checkbox-control" name="hide_title" type="checkbox" <?php echo $hide_title_checked; ?>>
+				<input id="hide-title-checkbox-control" name="hide_title" type="checkbox" <?php checked( $hide_title, 1 ); ?>>
 			</span>
 			<label class="components-checkbox-control__label" for="hide-title-checkbox-control">Hide Title</label>
 		</div>
@@ -205,6 +206,8 @@ add_action('add_meta_boxes', 'emma_add_layout_options_metabox');
  * Save layout options postdata
  */
 function emma_save_layout_options_postdata( $post_id ) {
+	if ( empty( $_POST['layout_options_meta_box_nonce'] ) || ! wp_verify_nonce( $_POST['layout_options_meta_box_nonce'], basename(__FILE__) ) ) return;
+
 	// hide_title
 	if( array_key_exists( 'hide_title', $_POST ) ) {
 		update_post_meta(	$post_id,	'hide_title',	1	);


### PR DESCRIPTION
The `Layout Options` metabox was occasionally clearing values on refresh. If the page was subsequently saved, values in the database would be overwritten with the (non)values that were last loaded. For instance, a page with the `Hide Title` option checked would load in the editor with that checkbox _unchecked_ (despite having the value in the database). If the page was then updated in the editor, it would see that the `Hide Title` checkbox was unchecked and then save the option in the database as such, showing the title on the frontend.

This was happening a _lot_, but I really struggled to replicate the issue. I was finally able to replicate it by opening a page in the editor, confirming the `Hide Title` box was checked, pressing `Update`, and then refreshing the page _before the update had completed_. I doubt this was the mechanism that was causing the issue in the wild, but it was at least something I could test.

Adding a nonce field seemed to solve the issue, although I have no idea why. The problem was on value retrieval, not on saving. I will keep an eye on this as we develop new sites to see if the issue is actually resolved.