### PR TITLE
added back drawer CSS for backward compatibility

### DIFF
--- a/src/sass/navigation/_drawer.scss
+++ b/src/sass/navigation/_drawer.scss
@@ -2,6 +2,7 @@
   position: fixed;
   height: 100%;
   width: 100%;
+  transform: translateX( -100% );
   z-index: 10;
   top: 0;
   left: 0;


### PR DESCRIPTION
in case new theme is pulled in and compiled, but emma isn't uploaded with its new inline style, this will maintain existing functionality