### PR TITLE
added support for gtag.js

### DIFF
--- a/src/js/analytics-events.js
+++ b/src/js/analytics-events.js
@@ -1,11 +1,19 @@
 var Analytics = function() {
   return {
     fireEvent: function( eventCategory, eventAction, eventLabel ) {
+      //fires events for universal analytics when UA is enqueued via analytics.js or GTM
       if( typeof ga === 'function' ) {
         var tracker = ga.getAll()[0];
         if( tracker ) {
           tracker.send( 'event', eventCategory, eventAction, eventLabel );
         }
+      }
+      //fires events for UA or GAv4 when using Global Site Tag
+      if( typeof gtag === 'function' ) {
+        gtag( 'event', eventAction, {
+          'event_category': eventCategory,
+          'event_label': eventLabel,
+        } );
       }
     }
   }


### PR DESCRIPTION
This will add event firing support for Google's Global Site Tag. This is the preferred method of enqueuing Analytics now that v4 is released. Events will be fired to both `Universal Analytics` _and_ `Analytics v4` when they are enqueued via Global Site Tag (and will continue to fire events to `Universal Analytics` when enqueue via Google Tag Manager or `analytics.js`).