### PR TITLE
set menu items to align center vertically

### DIFF
--- a/src/sass/navigation/_site.scss
+++ b/src/sass/navigation/_site.scss
@@ -45,6 +45,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: $menu-justify-content;
+    align-items: $menu-align-items;
   }
 
   .sub-menu {

--- a/src/sass/variables/_navigation.scss
+++ b/src/sass/variables/_navigation.scss
@@ -11,6 +11,7 @@ $menu-link-padding: $spacer-sm !default;
 $menu-link-padding-x: $menu-link-padding !default;
 $menu-link-padding-y: $menu-link-padding !default;
 $menu-justify-content: space-between !default;
+$menu-align-items: center !default;
 
 // Submenu - Global
 $menu-sub-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2) !default;


### PR DESCRIPTION
This is mainly to account for the new border around buttons - buttons in the menu are now larger than their normal link counterparts, and were off on vertical alignment

However, this will also help in the case of links that use word wrapping.