### PR TITLE
Fix the script naming conventions and hook

### DIFF
--- a/inc/enqueues.php
+++ b/inc/enqueues.php
@@ -8,13 +8,13 @@ function emma_enqueue_editor() {
    * Compiled JS
    */
   $emma_admin_js = get_stylesheet_directory_uri() . '/dist/admin.js';
-  wp_enqueue_script( 'admin-js', $emma_admin_js, ['wp-blocks','wp-editor'], true );
+  wp_enqueue_script( 'emma-admin', $emma_admin_js, ['wp-blocks','wp-editor'], true );
 
   /**
    * Compiled SASS
    */
   $emma_admin_css = get_stylesheet_directory_uri() . '/dist/admin.css';
-  wp_enqueue_style( 'emma-admin-css', $emma_admin_css );
+  wp_enqueue_style( 'emma-admin', $emma_admin_css );
 
 }
-add_action( 'enqueue_block_editor_assets', 'emma_enqueue_editor' );
+add_action( 'admin_enqueue_scripts', 'emma_enqueue_editor' );

--- a/src/admin.js
+++ b/src/admin.js
@@ -5,5 +5,5 @@
 // CSS
 import './sass/emma-admin.scss';
 
-// JS 
+// JS
 import './js/emma-admin';


### PR DESCRIPTION
Our current implementation of admin enqueues needed some tweaking for consistency.

- Add `emma-` prefix consistently
- Remove the `-css` and `-js` suffix as they are appended automatically
- Hook the `admin` scripts to the `admin_enqueue_scripts` hook. **

** As a point of clarity, if we truly want to hook CSS and JS to `enqueue_block_editor_assets` then we should have files named `editor.js` and `emma-editor.js` defined in the theme for that purpose.