### PR TITLE
Refinement/post thumbnails

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -465,6 +465,21 @@ function emma_show_post_thumbnail() {
 }
 
 /**
+ * Filter `post_class` output for `has-post-thumbnail` based on thumbnail visibility
+ */
+function emma_has_post_thumbnail_filter( $classes ) {
+	$key = array_search( 'has-post-thumbnail', $classes );
+
+	// remove `has-post-thumbnail` if the thumbnail is not visible
+	if( false !== $key && ! emma_show_post_thumbnail() ) {
+		unset( $classes[ $key ] );
+	}
+
+	return $classes;
+}
+add_filter( 'post_class', 'emma_has_post_thumbnail_filter' );
+
+/**
  * Declare WooCommerce theme support.
  */
 function emma_declare_woocommerce_support() {

--- a/functions.php
+++ b/functions.php
@@ -446,6 +446,25 @@ function emma_get_layout_option( $post_id = null ) {
 }
 
 /**
+ * Check post thumbnail visibility within the loop
+ */
+function emma_show_post_thumbnail() {
+	if (
+		post_password_required()
+		|| is_attachment()
+		|| ! has_post_thumbnail()
+		|| ( is_search() && ! get_theme_mod( 'search_show_thumbnails', false ) )
+		|| ( ( is_home() || is_archive() ) && ! get_theme_mod( 'archive_show_thumbnails', false ) )
+		|| ( is_single() && ! get_theme_mod( 'post_show_thumbnails', false ) )
+		|| ( is_page() && ! get_theme_mod( 'page_show_thumbnails', false ) )
+	) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * Declare WooCommerce theme support.
  */
 function emma_declare_woocommerce_support() {

--- a/functions.php
+++ b/functions.php
@@ -455,6 +455,7 @@ function emma_show_post_thumbnail() {
 		|| ! has_post_thumbnail()
 		|| ( is_search() && ! get_theme_mod( 'search_show_thumbnails', false ) )
 		|| ( ( is_home() || is_archive() ) && ! get_theme_mod( 'archive_show_thumbnails', false ) )
+		|| ( is_front_page() && ! get_theme_mod( 'homepage_show_thumbnails', false ) )
 		|| ( is_single() && ! get_theme_mod( 'post_show_thumbnails', false ) )
 		|| ( is_page() && ! get_theme_mod( 'page_show_thumbnails', false ) )
 	) {

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -139,10 +139,10 @@ function emma_customize_register( $wp_customize ) {
 		'label' => 'Show Thumbnails',
 	) );
 
-	$wp_customize->add_section( 'posts_and_pages', array(
+	$wp_customize->add_section( 'posts', array(
 		'priority' => 10,
 		'theme_supports' => '',
-		'title' => 'Posts & Pages',
+		'title' => 'Posts',
 		'description' => '',
 		'panel' => 'theme_settings',
 	) );
@@ -151,16 +151,24 @@ function emma_customize_register( $wp_customize ) {
 	$wp_customize->add_control( 'post_show_thumbnails', array(
 		'type' => 'checkbox',
 		'priority' => 10,
-		'section' => 'posts_and_pages',
-		'label' => 'Show Featured Image on Posts',
+		'section' => 'posts',
+		'label' => 'Show Featured Image',
+	) );
+
+	$wp_customize->add_section( 'pages', array(
+		'priority' => 10,
+		'theme_supports' => '',
+		'title' => 'Pages',
+		'description' => '',
+		'panel' => 'theme_settings',
 	) );
 
 	$wp_customize->add_setting( 'page_show_thumbnails' );
 	$wp_customize->add_control( 'page_show_thumbnails', array(
 		'type' => 'checkbox',
 		'priority' => 10,
-		'section' => 'posts_and_pages',
-		'label' => 'Show Featured Image on Pages',
+		'section' => 'pages',
+		'label' => 'Show Featured Image',
 	) );
 }
 add_action( 'customize_register', 'emma_customize_register' );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -83,6 +83,22 @@ function emma_customize_register( $wp_customize ) {
 		],
 	) );
 
+	$wp_customize->add_section( 'homepage', array(
+		'priority' => 10,
+		'theme_supports' => '',
+		'title' => 'Homepage',
+		'description' => '',
+		'panel' => 'theme_settings',
+	) );
+
+	$wp_customize->add_setting( 'homepage_show_thumbnails' );
+	$wp_customize->add_control( 'homepage_show_thumbnails', array(
+		'type' => 'checkbox',
+		'priority' => 10,
+		'section' => 'homepage',
+		'label' => 'Show Featured Image',
+	) );
+
 	$wp_customize->add_section( 'archives', array(
 		'priority' => 10,
 		'theme_supports' => '',
@@ -136,7 +152,7 @@ function emma_customize_register( $wp_customize ) {
 		'type' => 'checkbox',
 		'priority' => 10,
 		'section' => 'posts_and_pages',
-		'label' => 'Show Thumbnails on Posts',
+		'label' => 'Show Featured Image on Posts',
 	) );
 
 	$wp_customize->add_setting( 'page_show_thumbnails' );
@@ -144,7 +160,7 @@ function emma_customize_register( $wp_customize ) {
 		'type' => 'checkbox',
 		'priority' => 10,
 		'section' => 'posts_and_pages',
-		'label' => 'Show Thumbnails on Pages',
+		'label' => 'Show Featured Image on Pages',
 	) );
 }
 add_action( 'customize_register', 'emma_customize_register' );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -136,7 +136,7 @@ function emma_customize_register( $wp_customize ) {
 		'type' => 'checkbox',
 		'priority' => 10,
 		'section' => 'posts_and_pages',
-		'label' => 'Show Thumbnails on Blog Posts',
+		'label' => 'Show Thumbnails on Posts',
 	) );
 
 	$wp_customize->add_setting( 'page_show_thumbnails' );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -122,6 +122,30 @@ function emma_customize_register( $wp_customize ) {
 		'section' => 'search',
 		'label' => 'Show Thumbnails',
 	) );
+
+	$wp_customize->add_section( 'posts_and_pages', array(
+		'priority' => 10,
+		'theme_supports' => '',
+		'title' => 'Posts & Pages',
+		'description' => '',
+		'panel' => 'theme_settings',
+	) );
+
+	$wp_customize->add_setting( 'post_show_thumbnails' );
+	$wp_customize->add_control( 'post_show_thumbnails', array(
+		'type' => 'checkbox',
+		'priority' => 10,
+		'section' => 'posts_and_pages',
+		'label' => 'Show Thumbnails on Blog Posts',
+	) );
+
+	$wp_customize->add_setting( 'page_show_thumbnails' );
+	$wp_customize->add_control( 'page_show_thumbnails', array(
+		'type' => 'checkbox',
+		'priority' => 10,
+		'section' => 'posts_and_pages',
+		'label' => 'Show Thumbnails on Pages',
+	) );
 }
 add_action( 'customize_register', 'emma_customize_register' );
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -165,9 +165,6 @@ function emma_layout_options_metabox_html( $post, $metabox ) {
 	// post_layout
 	$post_layout = get_post_meta( $post->ID, 'post_layout', true );
 
-	// feature_image_before_title
-	$featured_image_before_title = get_post_meta( $post->ID, 'featured_image_before_title', true );
-
 	wp_nonce_field( basename(__FILE__), 'layout_options_meta_box_nonce' );
 	?>
 

--- a/inc/template-parts.php
+++ b/inc/template-parts.php
@@ -69,19 +69,11 @@ add_action( 'emma_after_header', 'emma_primary_navigation_template' );
 /**
  * Gets the post thumbnail template part.
  */
-function emma_post_thumbnail_template_singular() {
-	if( is_singular() ) {
-		emma_post_thumbnail();
-	}
+function emma_post_thumbnail_template() {
+	$size = ( is_singular() ) ? null : 'thumbnail';
+	emma_post_thumbnail( $size );
 }
-add_action( 'emma_after_entry_header', 'emma_post_thumbnail_template_singular' );
-
-function emma_post_thumbnail_template_archive() {
-	if( ! is_singular() ) {
-		emma_post_thumbnail( 'thumbnail' );
-	}
-}
-add_action( 'emma_before_entry_header', 'emma_post_thumbnail_template_archive' );
+add_action( 'emma_after_entry_header', 'emma_post_thumbnail_template' );
 
 /**
  * Gets the entry header template part.

--- a/inc/template-parts.php
+++ b/inc/template-parts.php
@@ -69,10 +69,19 @@ add_action( 'emma_after_header', 'emma_primary_navigation_template' );
 /**
  * Gets the post thumbnail template part.
  */
-function emma_post_thumbnail_template() {
-	emma_post_thumbnail();
+function emma_post_thumbnail_template_singular() {
+	if( is_singular() ) {
+		emma_post_thumbnail();
+	}
 }
-add_action( 'emma_after_entry_header', 'emma_post_thumbnail_template' );
+add_action( 'emma_after_entry_header', 'emma_post_thumbnail_template_singular' );
+
+function emma_post_thumbnail_template_archive() {
+	if( ! is_singular() ) {
+		emma_post_thumbnail( 'thumbnail' );
+	}
+}
+add_action( 'emma_before_entry_header', 'emma_post_thumbnail_template_archive' );
 
 /**
  * Gets the entry header template part.

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -99,53 +99,47 @@ if ( ! function_exists( 'emma_post_thumbnail' ) ) :
 	 * Displays an optional post thumbnail.
 	 *
 	 * Wraps the post thumbnail in a div and adds an anchor element around the
-   * thumbnail on index views.
+	 * thumbnail on index views.
 	 */
 	function emma_post_thumbnail( $size = 'post-thumbnail' ) {
-		if ( post_password_required()
-			|| is_attachment()
-			|| ! has_post_thumbnail()
-			|| ( is_search() && ! get_theme_mod( 'search_show_thumbnails', false ) )
-			|| ( ( is_home() || is_archive() ) && ! get_theme_mod( 'archive_show_thumbnails', false ) )
-			|| ( is_single() && ! get_theme_mod( 'post_show_thumbnails', false ) )
-			|| ( is_page() && ! get_theme_mod( 'page_show_thumbnails', false ) )
-		) {
+		// exit early if the thumbnail should not be shown
+		if ( ! emma_show_post_thumbnail() ) {
 			return;
-    }
-    ?>
+		}
+		?>
 
-    <div class="post-thumbnail">
+		<div class="post-thumbnail">
 
-    <?php
-		if ( ! is_singular() ) :
-      ?>
+			<?php
+			if ( ! is_singular() ) :
+				?>
 
-      <a href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
+				<a href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
 
-      <?php
-    endif; // End ! is_singular().
+				<?php
+			endif; // End ! is_singular().
 
-    if ( is_singular() ) :
-      the_post_thumbnail();
-    else :
-      the_post_thumbnail( $size, array(
-				'alt' => the_title_attribute( array(
-					'echo' => false,
-				) ),
-			) );
-    endif; // End is_singular().
+			if ( is_singular() ) :
+				the_post_thumbnail();
+			else :
+				the_post_thumbnail( $size, array(
+					'alt' => the_title_attribute( array(
+						'echo' => false,
+					) ),
+				) );
+			endif; // End is_singular().
 
-    if ( ! is_singular() ) :
-      ?>
+			if ( ! is_singular() ) :
+				?>
 
-      </a>
+				</a>
 
-      <?php
-    endif; // End ! is_singular().
-    ?>
+				<?php
+			endif; // End ! is_singular().
+			?>
 
-    </div><!-- .post-thumbnail -->
+		</div><!-- .post-thumbnail -->
 
-    <?php
-  }
+		<?php
+	}
 endif;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -101,7 +101,7 @@ if ( ! function_exists( 'emma_post_thumbnail' ) ) :
 	 * Wraps the post thumbnail in a div and adds an anchor element around the
    * thumbnail on index views.
 	 */
-	function emma_post_thumbnail() {
+	function emma_post_thumbnail( $size = 'post-thumbnail' ) {
 		if ( post_password_required()
 			|| is_attachment()
 			|| ! has_post_thumbnail()
@@ -128,7 +128,7 @@ if ( ! function_exists( 'emma_post_thumbnail' ) ) :
     if ( is_singular() ) :
       the_post_thumbnail();
     else :
-      the_post_thumbnail( 'post-thumbnail', array(
+      the_post_thumbnail( $size, array(
 				'alt' => the_title_attribute( array(
 					'echo' => false,
 				) ),

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -107,6 +107,8 @@ if ( ! function_exists( 'emma_post_thumbnail' ) ) :
 			|| ! has_post_thumbnail()
 			|| ( is_search() && ! get_theme_mod( 'search_show_thumbnails', false ) )
 			|| ( ( is_home() || is_archive() ) && ! get_theme_mod( 'archive_show_thumbnails', false ) )
+			|| ( is_single() && ! get_theme_mod( 'post_show_thumbnails', false ) )
+			|| ( is_page() && ! get_theme_mod( 'page_show_thumbnails', false ) )
 		) {
 			return;
     }

--- a/src/sass/site/_posts-and-pages.scss
+++ b/src/sass/site/_posts-and-pages.scss
@@ -128,12 +128,42 @@
   .page-content {
     .entry-header {
       text-align: left;
+      margin-top: 0;
     }
   }
 
   article {
+    padding-top: $spacer-lg;
+    padding-bottom: $spacer-lg;
+
+    &::before,
+    &::after {
+      content: '';
+      display: table;
+      clear: both;
+    }
+
     &:not( :last-child ) {
       border-bottom: $posts-border-bottom;
+    }
+
+    .entry-content {
+      > :last-child() {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  .post-thumbnail {
+    display: none;
+    
+    @media screen and ( min-width: $breakpoint-xs ) {
+      display: block;
+      float: left;
+      max-width: 50%;
+      margin-bottom: $spacer-sm;
+      margin-right: $spacer;
+      margin-top: 0;
     }
   }
 }

--- a/src/sass/site/_posts-and-pages.scss
+++ b/src/sass/site/_posts-and-pages.scss
@@ -167,6 +167,25 @@
   }
 }
 
+.search {
+  .search-form {
+    display: flex;
+    margin-top: $spacer;
+    margin-bottom: $spacer;
+    align-items: center;
+
+    label {
+      flex-grow: 1;
+      margin-bottom: 0;
+      margin-right: $spacer-sm;
+    }
+
+    .search-field {
+      width: 100%;
+    }
+  }
+}
+
 .wp-block-group.has-background,
 .wp-block-group.border {
   > .wp-block-group__inner-container {

--- a/src/sass/site/_posts-and-pages.scss
+++ b/src/sass/site/_posts-and-pages.scss
@@ -148,6 +148,12 @@
 	}
   }
 
+  .entry-footer {
+    @media screen and ( min-width: $breakpoint-xs ) {
+      grid-column: 1 / span 2;
+    }
+  }
+
   .has-post-thumbnail {
     @media screen and ( min-width: $breakpoint-xs ) {
       grid-template-columns: 125px 1fr;

--- a/src/sass/site/_posts-and-pages.scss
+++ b/src/sass/site/_posts-and-pages.scss
@@ -125,84 +125,47 @@
 .archive,
 .blog,
 .search {
-  .page-content {
-    .entry-header {
-      text-align: left;
-      margin-top: 0;
-    }
-  }
-
-  article {
-    padding-top: $spacer-lg;
-    padding-bottom: $spacer-lg;
-
-    &::before,
-    &::after {
-      content: '';
-      display: table;
-      clear: both;
-    }
+  .post,
+  .search-result {
+    display: grid;
+    row-gap: $spacer-sm;
+    column-gap: $spacer;
+    margin-top: $spacer-lg;
+    margin-bottom: $spacer-lg;
 
     &:not( :last-child ) {
       border-bottom: $posts-border-bottom;
     }
+  }
 
-    .entry-content {
-      > :last-child() {
-        margin-bottom: 0;
+  .entry-header {
+    margin-top: 0;
+    margin-bottom: 0;
+	text-align: left;
+
+    @media screen and ( min-width: $breakpoint-xs ) {
+      grid-column: 1 / span 2;
+	}
+  }
+
+  .has-post-thumbnail {
+    @media screen and ( min-width: $breakpoint-xs ) {
+      grid-template-columns: 125px 1fr;
+
+      .entry-content {
+        grid-column: 2;
       }
-    }
+	}
   }
 
   .post-thumbnail {
     display: none;
-    
+
     @media screen and ( min-width: $breakpoint-xs ) {
       display: block;
-      float: left;
-      max-width: 50%;
-      margin-bottom: $spacer-sm;
-      margin-right: $spacer;
-      margin-top: 0;
     }
   }
 }
-
-.search-results {
-  .page-content {
-    .search-form {
-      display: flex;
-      margin-top: $spacer;
-      margin-bottom: $spacer;
-      align-items: center;
-
-      label {
-        flex-grow: 1;
-        margin-bottom: 0;
-        margin-right: $spacer-sm;
-      }
-
-      .search-field {
-        width: 100%;
-      }
-    }
-
-    .entry-header {
-      margin-bottom: $spacer;
-    }
-
-    .entry-title {
-      margin-bottom: 0;
-    }
-  }
-}
-
-.search-result {
-  .post-thumbnail {
-    margin-bottom: 0;
-  }
-}
-
 
 .wp-block-group.has-background,
 .wp-block-group.border {

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -10,20 +10,19 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class( 'search-result' ); ?>>
+
+	<?php emma_post_thumbnail( 'thumbnail' ); ?>
+
 	<header class="entry-header">
 		<div class="wrap">
 
       <?php
-      the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
-
-      //get_template_part( 'template-parts/entry', 'meta' );
+      	the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
 			?>
 
       <small><a href="<?php echo get_permalink(); ?>"><?php echo get_permalink(); ?></a></small>
 		</div><!-- .wrap -->
 	</header><!-- .entry-header -->
-
-	<?php emma_post_thumbnail(); ?>
 
 	<div class="entry-content">
 

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -11,22 +11,22 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class( 'search-result' ); ?>>
 
-	<?php emma_post_thumbnail( 'thumbnail' ); ?>
-
 	<header class="entry-header">
 		<div class="wrap">
 
-      <?php
-      	the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
-			?>
+			<?php the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' ); ?>
 
-      <small><a href="<?php echo get_permalink(); ?>"><?php echo get_permalink(); ?></a></small>
+			<small><a href="<?php echo get_permalink(); ?>"><?php echo get_permalink(); ?></a></small>
+
 		</div><!-- .wrap -->
 	</header><!-- .entry-header -->
+
+	<?php emma_post_thumbnail( 'thumbnail' ); ?>
 
 	<div class="entry-content">
 
 		<?php the_excerpt(); ?>
 
 	</div><!-- .entry-content -->
+
 </article><!-- #post-<?php the_ID(); ?> -->


### PR DESCRIPTION
@dswebsme This is ready for testing. There are a few areas that seem pretty janky to me, especially the changes in `inc/template-parts.php`. I'm curious if you know of a better way to handle that (using different hooks for singular vs archival). 

I also noticed that the `search.php` template doesn't use the same hook that the other templates do, so I handled that differently. That was my doing a long time ago when I customized the search template. I could try to unify that with the other templates and hook the `post-thumbnail` in appropriately rather than calling it directly.

I know we're also talking about doing a pretty significant template rework, so I'm also cool with rolling with this and refining later.