### PR TITLE
updated css-loader to not attempt to load in urls directly

### DIFF
--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -47,7 +47,10 @@ module.exports = {
 				test: /\.(css|scss)$/,
 				use: [
 					MiniCssExtractPlugin.loader,
-					"css-loader",
+					{
+						loader: "css-loader",
+						options: { url: false }
+					},
 					{
 						loader: "postcss-loader",
 					},


### PR DESCRIPTION
Prior to this change, attempting to assign a `background-image` via a `url()` value would result in an error. This allows for relative reference of media in the WP media library (via something like `background-image: url("/wp-content/uploads/...")`.