### PR TITLE
Button Tweaks

### DIFF
--- a/src/sass/forms/_buttons.scss
+++ b/src/sass/forms/_buttons.scss
@@ -12,7 +12,8 @@ $button-selectors: $button-selectors-admin !default;
 	border-radius: $button-border-radius;
 
 	&:visited {
-		color: var(--color); //needed to override styles from Gutenberg stylesheet on :active, :focus, :hover, and :visited
+		// override styles from Gutenberg stylesheet on :visited
+		color: var(--color);
 	}
 
 	&:active, &:focus {
@@ -26,7 +27,8 @@ $button-selectors: $button-selectors-admin !default;
 		background-color: var(--bg-color-contrast-sm);
 		border-color: var(--bg-color-contrast-sm);
 		text-decoration: none;
-		color: var(--color); //needed to override styles from Gutenberg stylesheet on :active, :focus, :hover, and :visited
+		// override styles from Gutenberg stylesheet on :active, :focus and :hover
+		color: var(--color);
 	}
 
 	&:disabled, &.disabled:not( :disabled ), &.loading {

--- a/src/sass/forms/_buttons.scss
+++ b/src/sass/forms/_buttons.scss
@@ -5,7 +5,7 @@ $button-selectors: $button-selectors-admin !default;
 }
 
 #{$button-selectors} {
-	@include background-color( $primary );
+	@include background-color( $button-background-color );
 	display: inline-block;
 	padding: $button-padding;
 	border: 2px solid var(--bg-color);

--- a/src/sass/forms/_buttons.scss
+++ b/src/sass/forms/_buttons.scss
@@ -8,7 +8,7 @@ $button-selectors: $button-selectors-admin !default;
 	@include background-color( $button-background-color );
 	display: inline-block;
 	padding: $button-padding;
-	border: 2px solid var(--bg-color);
+	border: $button-border var(--bg-color);
 	border-radius: $button-border-radius;
 
 	&:visited {

--- a/src/sass/forms/_buttons.scss
+++ b/src/sass/forms/_buttons.scss
@@ -30,12 +30,12 @@ $button-selectors: $button-selectors-admin !default;
 	}
 
 	&:disabled, &.disabled:not( :disabled ), &.loading {
-    filter: $button-disabled-filter-effect;
+		filter: $button-disabled-filter-effect;
 		cursor: not-allowed;
 
 		&:active, &:focus {
-      box-shadow: none;
-    }
+			box-shadow: none;
+		}
 	}
 
 	&.loading {
@@ -44,7 +44,7 @@ $button-selectors: $button-selectors-admin !default;
 		&::before {
 			content: "\f463";
 			animation: loading-spin 1s infinite;
-   		animation-timing-function: linear;
+			animation-timing-function: linear;
 			position: absolute;
 			top: 50%;
 			left: 50%;
@@ -61,7 +61,7 @@ $button-selectors: $button-selectors-admin !default;
 			100% {
 				 transform: translate( -50%, -50% ) rotate( 360deg );
 			}
-	 	}
+		}
 	}
 }
 

--- a/src/sass/mixins/_mixins.scss
+++ b/src/sass/mixins/_mixins.scss
@@ -1,8 +1,8 @@
 // Center wrap
 @mixin center-wrap($maxWidth) {
-  margin-left: auto;
-  margin-right: auto;
-  max-width: $maxWidth;
+	margin-left: auto;
+	margin-right: auto;
+	max-width: $maxWidth;
 }
 
 // Center block
@@ -44,12 +44,12 @@
 	}
 
 	&:disabled, &.disabled:not( :disabled ), &.loading {
-    filter: $button-disabled-filter-effect;
+		filter: $button-disabled-filter-effect;
 		cursor: not-allowed;
 
 		&:active, &:focus {
-      box-shadow: none;
-    }
+			box-shadow: none;
+		}
 	}
 
 	&.loading {
@@ -58,7 +58,7 @@
 		&::before {
 			content: "\f463";
 			animation: loading-spin 1s infinite;
-   		animation-timing-function: linear;
+			animation-timing-function: linear;
 			position: absolute;
 			top: 50%;
 			left: 50%;
@@ -74,7 +74,7 @@
 			100% {
 				 transform: translate( -50%, -50% ) rotate( 360deg );
 			}
-	 }
+		}
 	}
 }
 
@@ -115,32 +115,32 @@
 @mixin sr-only-focusable-fixed() {
 	@include sr-only-focusable;
 
-  &:focus {
-    display: block;
-    position: fixed;
-    left: 6px;
-    top: 7px;
-    height: auto;
-    width: auto;
-    display: block;
-    font-size: 14px;
-    font-weight: 600;
-    padding: 15px 23px 14px;
-    background: #f1f1f1;
-    color: #0073aa;
-    z-index: 100000;
-    line-height: normal;
-    text-decoration: none;
-    box-shadow: 0 0 2px 2px rgba(0,0,0,.6);
-    box-sizing: content-box;
-    outline-offset: -1px;
-  }
+	&:focus {
+		display: block;
+		position: fixed;
+		left: 6px;
+		top: 7px;
+		height: auto;
+		width: auto;
+		display: block;
+		font-size: 14px;
+		font-weight: 600;
+		padding: 15px 23px 14px;
+		background: #f1f1f1;
+		color: #0073aa;
+		z-index: 100000;
+		line-height: normal;
+		text-decoration: none;
+		box-shadow: 0 0 2px 2px rgba(0,0,0,.6);
+		box-sizing: content-box;
+		outline-offset: -1px;
+	}
 }
 
 @mixin grid-template-columns-responsive( $min-width ) {
-  @media screen and ( min-width: calc( #{$min-width} * 2 ) ) {
-    grid-template-columns: repeat( auto-fill, minmax( $min-width, 1fr ) );
-  }
+	@media screen and ( min-width: calc( #{$min-width} * 2 ) ) {
+		grid-template-columns: repeat( auto-fill, minmax( $min-width, 1fr ) );
+	}
 }
 
 @mixin d-none-overlay() {
@@ -177,15 +177,15 @@
 // See: https://hugogiraudel.com/2016/10/13/css-hide-and-seek/
 
 @mixin sr-only {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  padding: 0 !important;
-  margin: -1px !important; // Fix for https://github.com/twbs/bootstrap/issues/25686
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  white-space: nowrap !important;
-  border: 0 !important;
+	position: absolute !important;
+	width: 1px !important;
+	height: 1px !important;
+	padding: 0 !important;
+	margin: -1px !important; // Fix for https://github.com/twbs/bootstrap/issues/25686
+	overflow: hidden !important;
+	clip: rect(0, 0, 0, 0) !important;
+	white-space: nowrap !important;
+	border: 0 !important;
 }
 
 // Use to only display content when it's focused.
@@ -193,17 +193,17 @@
 // Useful for "Skip to main content" links; see https://www.w3.org/TR/2013/NOTE-WCAG20-TECHS-20130905/G1
 
 @mixin sr-only-focusable {
-  &:not(:focus) {
-    @include sr-only();
-  }
+	&:not(:focus) {
+		@include sr-only();
+	}
 }
 
 @mixin clearfix() {
-  &::after {
-    display: block;
-    clear: both;
-    content: "";
-  }
+	&::after {
+		display: block;
+		clear: both;
+		content: "";
+	}
 }
 
 /*--------------------------------------------------------------

--- a/src/sass/mixins/_mixins.scss
+++ b/src/sass/mixins/_mixins.scss
@@ -25,59 +25,6 @@
 	}
 }
 
-// Button format
-@mixin button() {
-	display: inline-block;
-	padding: $button-padding;
-	border: $button-border;
-	border-radius: $button-border-radius;
-
-	&:hover,
-	&:active,
-	&:focus {
-		filter: $button-hover-filter-effect;
-		text-decoration: none;
-	}
-
-	&:active, &:focus {
-		outline: 0;
-	}
-
-	&:disabled, &.disabled:not( :disabled ), &.loading {
-		filter: $button-disabled-filter-effect;
-		cursor: not-allowed;
-
-		&:active, &:focus {
-			box-shadow: none;
-		}
-	}
-
-	&.loading {
-		color: transparent !important;
-
-		&::before {
-			content: "\f463";
-			animation: loading-spin 1s infinite;
-			animation-timing-function: linear;
-			position: absolute;
-			top: 50%;
-			left: 50%;
-			transform: translate( -50%, -50% );
-			font-family: 'dashicons';
-			font-size: $base-unit * 1.5;
-		}
-
-		@keyframes loading-spin {
-			0% {
-				 transform: translate( -50%, -50% ) rotate( 0deg );
-			}
-			100% {
-				 transform: translate( -50%, -50% ) rotate( 360deg );
-			}
-		}
-	}
-}
-
 @mixin color( $color ) {
 	color: var(--color);
 	@include color-custom-properties( $color );

--- a/src/sass/variables/_colors.scss
+++ b/src/sass/variables/_colors.scss
@@ -71,3 +71,5 @@ $footer-background-color: $primary-support !default;
 $input-color: #666 !default;
 $input-color-focus: #111 !default;
 $input-border-color: #ccc !default;
+
+$button-background-color: $primary !default;

--- a/src/sass/variables/_woocommerce.scss
+++ b/src/sass/variables/_woocommerce.scss
@@ -12,17 +12,23 @@ $wc-product-gallery-row-gap: $wc-product-gallery-column-gap !default;
 $wc-cart-form-margin-bottom: $spacer-lg !default;
 
 // Shop page min widths
-// controls the number of columns displayed on the shop page - grid will create as many columns as possible as long as they are at least these widths (selectable on shop page)
+// controls the number of columns displayed on the shop page - grid will create as many columns
+// as possible as long as they are at least these widths (selectable on shop page)
 $wc-shop-product-min-width-sm: 200px !default;
 $wc-shop-product-min-width-md: 250px !default;
 $wc-shop-product-min-width-lg: 300px !default;
 
 // Product gallery min width
-// controls the number of columns displayed in the image gallery on the product page - uses same technique as above
+// controls the number of columns displayed in the image gallery on the product page - uses same
+// technique as above
 $wc-product-gallery-min-width: 80px !default;
 
 // Max widths
-$wc-max-width: $breakpoint-lg !default; // sets the max width of content on woocommerce pages
+// sets the max width of content on woocommerce pages
+$wc-max-width: $breakpoint-lg !default;
+
+// Buttons
+$wc-button-background-color: $accent !default;
 
 // Tables
 $wc-table-head-background-color: $gray-800 !default;

--- a/src/sass/variables/_woocommerce.scss
+++ b/src/sass/variables/_woocommerce.scss
@@ -28,7 +28,7 @@ $wc-product-gallery-min-width: 80px !default;
 $wc-max-width: $breakpoint-lg !default;
 
 // Buttons
-$wc-button-background-color: $accent !default;
+$wc-button-background-color: $button-background-color !default;
 
 // Tables
 $wc-table-head-background-color: $gray-800 !default;

--- a/src/sass/woocommerce/components/_buttons.scss
+++ b/src/sass/woocommerce/components/_buttons.scss
@@ -4,5 +4,5 @@ a.button.checkout-button,
 button#place_order,
 a.button.product_type_grouped,
 .woocommerce-message a.button {
-  @include background-color-custom-properties( $accent );
+	@include background-color-custom-properties( $wc-button-background-color );
 }

--- a/src/sass/woocommerce/components/_mini-cart.scss
+++ b/src/sass/woocommerce/components/_mini-cart.scss
@@ -108,7 +108,7 @@
       padding: $spacer-sm $spacer;
 
       &.checkout {
-        @include background-color-custom-properties( $accent );
+        @include background-color-custom-properties( $wc-button-background-color );
       }
     }
   }


### PR DESCRIPTION
Standardizes our implementation of buttons between Gutenberg and WooCommerce, specifically related to default colors.

Gutenberg previously defaulted buttons to `$primary` while WooCommerce defaulted to `$accent`.

New variables defined as `$button-background-color` and `$wc-button-background-color` both default to `$primary` and can be overridden as needed in the child theme.

Other minor adjustments include code cleanup, formatting and comment refinement.