### PR TITLE
Menu Drawer Background

### DIFF
--- a/src/sass/navigation/_drawer.scss
+++ b/src/sass/navigation/_drawer.scss
@@ -6,7 +6,7 @@
 	z-index: 10;
 	top: 0;
 	left: 0;
-	background-color: rgba(255, 255, 255, 0.95);
+	background: $menu-drawer-background;
 	overflow-x: hidden;
 	transition: all 0.25s ease-in-out;
 

--- a/src/sass/variables/_navigation.scss
+++ b/src/sass/variables/_navigation.scss
@@ -31,3 +31,4 @@ $menu-toggle-display: inline-block !default;
 $menu-drawer-padding: $spacer-md !default;
 $menu-drawer-padding-x: $menu-drawer-padding !default;
 $menu-drawer-padding-y: $menu-drawer-padding !default;
+$menu-drawer-background: rgba(255, 255, 255, 0.95) !default;


### PR DESCRIPTION
Give .menu-drawer a background variable in SCSS for easier override