### PR TITLE
Improve the default styling of various elements

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -125,9 +125,24 @@ function emma_custom_classes_metabox_html( $post ) {
 }
 
 /**
- * Add metabox for custom classes in all post types
+ * Add metabox for custom classes in supported post types
  */
 function emma_add_custom_classes_metabox() {
+	$context = 'custom_classes';
+
+	$supported_post_types = array(
+		'page',
+		'post',
+		'product',
+	);
+
+	$supported_post_types = apply_filters( 'emma_supported_post_types', $supported_post_types, $context );
+
+	// Exit early if not a supported post type.
+	if ( ! in_array( get_post_type(), $supported_post_types, true ) ) {
+		return;
+	}
+
 	add_meta_box( 'custom_classes', 'Custom Classes', 'emma_custom_classes_metabox_html', null, 'side' );
 }
 add_action( 'add_meta_boxes', 'emma_add_custom_classes_metabox' );
@@ -209,9 +224,24 @@ function emma_layout_options_metabox_html( $post, $metabox ) {
 }
 
 /**
- * Add metabox for layout options in all post types
+ * Add metabox for layout options in supported post types
  */
 function emma_add_layout_options_metabox() {
+	$context = 'layout_options';
+
+	$supported_post_types = array(
+		'page',
+		'post',
+		'product',
+	);
+
+	$supported_post_types = apply_filters( 'emma_supported_post_types', $supported_post_types, $context );
+
+	// Exit early if not a supported post type.
+	if ( ! in_array( get_post_type(), $supported_post_types, true ) ) {
+		return;
+	}
+
 	add_meta_box( 'layout_options', 'Layout Options', 'emma_layout_options_metabox_html', null, 'side' );
 }
 add_action( 'add_meta_boxes', 'emma_add_layout_options_metabox' );

--- a/src/sass/gutenberg/blocks/_wp-block-cover.scss
+++ b/src/sass/gutenberg/blocks/_wp-block-cover.scss
@@ -1,4 +1,6 @@
 .wp-block-cover,
 .wp-block-cover-image {
 	height: auto;
+	padding-left: 0;
+	padding-right: 0;
 }

--- a/src/sass/mixins/_mixins.scss
+++ b/src/sass/mixins/_mixins.scss
@@ -5,8 +5,8 @@
 	max-width: $maxWidth;
 }
 
-@mixin layout-wrap($spacer) {
-	width: calc(100% - #{$spacer} * 2);
+@mixin layout-wrap() {
+	width: calc(100% - #{ var( --layout-spacer-x ) } * 2);
 }
 
 // Center block

--- a/src/sass/mixins/_mixins.scss
+++ b/src/sass/mixins/_mixins.scss
@@ -5,6 +5,10 @@
 	max-width: $maxWidth;
 }
 
+@mixin layout-wrap($spacer) {
+	width: calc(100% - #{$spacer} * 2);
+}
+
 // Center block
 @mixin center-block {
 	display: block;

--- a/src/sass/navigation/_footer-widgets.scss
+++ b/src/sass/navigation/_footer-widgets.scss
@@ -1,0 +1,12 @@
+.footer-widgets {
+	.menu-container {
+		.menu {
+			display: block;
+
+			a {
+				padding-left: 0;
+				padding-right: 0;
+			}
+		}
+	}
+}

--- a/src/sass/navigation/_main.scss
+++ b/src/sass/navigation/_main.scss
@@ -7,6 +7,7 @@
 
 	> .wrap {
 		@include center-wrap($wrap-max-width);
-		padding: $main-navigation-wrap-padding-y $main-navigation-wrap-padding-x;
+		@include layout-wrap($layout-spacer-x);
+		padding: $main-navigation-wrap-padding;
 	}
 }

--- a/src/sass/navigation/_main.scss
+++ b/src/sass/navigation/_main.scss
@@ -7,7 +7,7 @@
 
 	> .wrap {
 		@include center-wrap($wrap-max-width);
-		@include layout-wrap($layout-spacer-x);
+		@include layout-wrap();
 		padding: $main-navigation-wrap-padding;
 	}
 }

--- a/src/sass/navigation/_navigation.scss
+++ b/src/sass/navigation/_navigation.scss
@@ -7,6 +7,9 @@
 @import "header-widgets";
 @import "utility-bar";
 
+// Footer widget menus
+@import "footer-widgets";
+
 // Footer menus
 @import "footer";
 

--- a/src/sass/navigation/_pagination.scss
+++ b/src/sass/navigation/_pagination.scss
@@ -3,7 +3,7 @@
 .post-navigation {
 	> .nav-links {
 		@include center-wrap($entry-footer-wrap-max-width);
-		width: calc(100% - #{$content-padding-x} * 2);
+		@include layout-wrap($layout-spacer-x);
 	}
 
 	.site-main & {

--- a/src/sass/navigation/_pagination.scss
+++ b/src/sass/navigation/_pagination.scss
@@ -3,7 +3,7 @@
 .post-navigation {
 	> .nav-links {
 		@include center-wrap($entry-footer-wrap-max-width);
-		@include layout-wrap($layout-spacer-x);
+		@include layout-wrap();
 	}
 
 	.site-main & {

--- a/src/sass/navigation/_site.scss
+++ b/src/sass/navigation/_site.scss
@@ -2,10 +2,6 @@
 	clear: both;
 	display: block;
 	width: 100%;
-
-	.menu-container {
-		padding: $menu-container-padding-y $menu-container-padding-x;
-	}
 }
 
 .menu-container {

--- a/src/sass/site/_comments.scss
+++ b/src/sass/site/_comments.scss
@@ -5,6 +5,16 @@
 	}
 }
 
+.comment-list {
+	padding-left: 0;
+	list-style-type: none;
+
+	.comment {
+		padding-left: 1rem;
+		border-left: 5px solid $gray-200;
+	}
+}
+
 .comment-content a {
 	word-wrap: break-word;
 }

--- a/src/sass/site/_comments.scss
+++ b/src/sass/site/_comments.scss
@@ -1,7 +1,7 @@
 .comments-area {
 	> .wrap {
 		@include center-wrap($comments-area-wrap-max-width);
-		width: calc(100% - #{$content-padding-x} * 2);
+		@include layout-wrap($layout-spacer-x);
 	}
 }
 

--- a/src/sass/site/_comments.scss
+++ b/src/sass/site/_comments.scss
@@ -1,7 +1,7 @@
 .comments-area {
 	> .wrap {
 		@include center-wrap($comments-area-wrap-max-width);
-		@include layout-wrap($layout-spacer-x);
+		@include layout-wrap();
 	}
 }
 

--- a/src/sass/site/_comments.scss
+++ b/src/sass/site/_comments.scss
@@ -11,7 +11,8 @@
 
 	.comment {
 		padding-left: 1rem;
-		border-left: 5px solid $gray-200;
+		border: $comment-border;
+		border-width: $comment-border-width;
 	}
 }
 

--- a/src/sass/site/_footer-widgets.scss
+++ b/src/sass/site/_footer-widgets.scss
@@ -5,6 +5,7 @@
 	> .wrap {
 		@include center-wrap($footer-widgets-wrap-max-width);
 		@include layout-wrap($layout-spacer-x);
+		padding: $footer-widgets-wrap-padding;
 		position: relative;
 		column-gap: $footer-widgets-wrap-column-gap;
 

--- a/src/sass/site/_footer-widgets.scss
+++ b/src/sass/site/_footer-widgets.scss
@@ -4,7 +4,7 @@
 
 	> .wrap {
 		@include center-wrap($footer-widgets-wrap-max-width);
-		@include layout-wrap($layout-spacer-x);
+		@include layout-wrap();
 		padding: $footer-widgets-wrap-padding;
 		position: relative;
 		column-gap: $footer-widgets-wrap-column-gap;

--- a/src/sass/site/_footer-widgets.scss
+++ b/src/sass/site/_footer-widgets.scss
@@ -1,9 +1,11 @@
 .footer-widgets {
+	color: $footer-widgets-color;
 	background-color: $footer-widgets-background-color;
 
 	> .wrap {
 		padding: $footer-widgets-wrap-padding-y $footer-widgets-wrap-padding-x;
 		position: relative;
+		column-gap: $footer-widgets-wrap-column-gap;
 
 		@include center-wrap($footer-widgets-wrap-max-width);
 
@@ -17,5 +19,17 @@
 	.widget-area {
 		flex-basis: $footer-widgets-widget-area-flex-basis;
 		flex-grow: $footer-widgets-widget-area-flex-grow;
+
+		a {
+			color: $footer-widgets-link-color;
+		}
+	}
+
+	.widget {
+		margin: $footer-widgets-widget-margin;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 }

--- a/src/sass/site/_footer-widgets.scss
+++ b/src/sass/site/_footer-widgets.scss
@@ -3,11 +3,10 @@
 	background-color: $footer-widgets-background-color;
 
 	> .wrap {
-		padding: $footer-widgets-wrap-padding-y $footer-widgets-wrap-padding-x;
+		@include center-wrap($footer-widgets-wrap-max-width);
+		@include layout-wrap($layout-spacer-x);
 		position: relative;
 		column-gap: $footer-widgets-wrap-column-gap;
-
-		@include center-wrap($footer-widgets-wrap-max-width);
 
 		@media screen and (min-width: $menu-breakpoint) {
 			display: flex;

--- a/src/sass/site/_footer.scss
+++ b/src/sass/site/_footer.scss
@@ -12,6 +12,10 @@
 
 		@include center-wrap($footer-wrap-max-width);
 	}
+
+	a {
+		color: $footer-link-color;
+	}
 }
 
 .site-info {

--- a/src/sass/site/_header.scss
+++ b/src/sass/site/_header.scss
@@ -2,15 +2,15 @@
 	background-color: $header-background-color;
 
 	> .wrap {
+		@include center-wrap($header-wrap-max-width);
+		@include layout-wrap($layout-spacer-x);
 		display: $header-wrap-display;
 		column-gap: $header-wrap-column-gap;
-		padding: $header-wrap-padding-y $header-wrap-padding-x;
+		padding: $header-wrap-padding;
 		position: relative;
 		align-items: $header-wrap-align-items;
 		justify-content: start;
 		grid-template-columns: $header-wrap-right-navigation-columns;
-
-		@include center-wrap($header-wrap-max-width);
 
 		@media screen and (min-width: $menu-breakpoint) {
 			justify-content: $header-wrap-justify-content;

--- a/src/sass/site/_header.scss
+++ b/src/sass/site/_header.scss
@@ -3,7 +3,7 @@
 
 	> .wrap {
 		display: $header-wrap-display;
-		grid-column-gap: $header-wrap-grid-column-gap;
+		column-gap: $header-wrap-column-gap;
 		padding: $header-wrap-padding-y $header-wrap-padding-x;
 		position: relative;
 		align-items: $header-wrap-align-items;

--- a/src/sass/site/_header.scss
+++ b/src/sass/site/_header.scss
@@ -3,7 +3,7 @@
 
 	> .wrap {
 		@include center-wrap($header-wrap-max-width);
-		@include layout-wrap($layout-spacer-x);
+		@include layout-wrap();
 		display: $header-wrap-display;
 		column-gap: $header-wrap-column-gap;
 		padding: $header-wrap-padding;

--- a/src/sass/site/_posts-and-pages.scss
+++ b/src/sass/site/_posts-and-pages.scss
@@ -12,7 +12,6 @@
 	display: grid;
 	grid-template-columns: $layout-content-columns;
 	column-gap: $layout-column-gap;
-	padding: $site-content-padding-y $site-content-padding-x;
 }
 
 .content-area {
@@ -70,7 +69,7 @@
 
 	> .wrap {
 		@include center-wrap($entry-header-wrap-max-width);
-		width: calc(100% - #{$content-padding-x} * 2);
+		@include layout-wrap($layout-spacer-x);
 	}
 }
 
@@ -103,7 +102,7 @@
 .page-content,
 .wp-block-cover__inner-container {
 	> * {
-		width: calc(100% - #{$content-padding-x} * 2);
+		@include layout-wrap($layout-spacer-x);
 	}
 }
 
@@ -198,7 +197,7 @@
 .wp-block-group.border {
 	> .wp-block-group__inner-container {
 		> * {
-			width: calc(100% - #{$content-padding-x} * 2);
+			@include layout-wrap($layout-spacer-x);
 
 			&.alignfull {
 				width: 100%; //needed because width declaration above this one supercedes normal .alignwide class unless the !important flag is used
@@ -216,8 +215,8 @@
 	.wp-block-group {
 		&.has-background,
 		&.border {
-			padding-top: $content-padding-x;
-			padding-bottom: $content-padding-x;
+			padding-top: $layout-spacer-y;
+			padding-bottom: $layout-spacer-y;
 		}
 	}
 
@@ -273,7 +272,7 @@ p.has-background {
 
 	> .wrap {
 		@include center-wrap($entry-footer-wrap-max-width);
-		width: calc(100% - #{$content-padding-x} * 2);
+		@include layout-wrap($layout-spacer-x);
 		display: flex;
 		flex-wrap: wrap;
 		align-items: $entry-footer-wrap-align-items;

--- a/src/sass/site/_posts-and-pages.scss
+++ b/src/sass/site/_posts-and-pages.scss
@@ -76,14 +76,6 @@
 .page-title,
 .entry-title {
 	margin-bottom: $spacer-xs;
-	//text-align: center;
-	//margin-top: $spacer-lg;
-	//margin-bottom: $spacer-lg;
-}
-
-.entry-meta {
-	//margin: 1.5rem 0;
-	//text-align: center;
 }
 
 .entry-content,
@@ -237,7 +229,6 @@
 	}
 }
 
-// @TODO: BEGIN Convert to SASS variables
 .entry-content,
 .wp-block-cover__inner-container,
 .wp-block-group__inner-container {
@@ -286,4 +277,3 @@ p.has-background {
 		text-align: center;
 	}
 }
-// @TODO: END Convert to SASS variables

--- a/src/sass/site/_posts-and-pages.scss
+++ b/src/sass/site/_posts-and-pages.scss
@@ -69,7 +69,7 @@
 
 	> .wrap {
 		@include center-wrap($entry-header-wrap-max-width);
-		@include layout-wrap($layout-spacer-x);
+		@include layout-wrap();
 	}
 }
 
@@ -94,7 +94,7 @@
 .page-content,
 .wp-block-cover__inner-container {
 	> * {
-		@include layout-wrap($layout-spacer-x);
+		@include layout-wrap();
 	}
 }
 
@@ -189,7 +189,7 @@
 .wp-block-group.border {
 	> .wp-block-group__inner-container {
 		> * {
-			@include layout-wrap($layout-spacer-x);
+			@include layout-wrap();
 
 			&.alignfull {
 				width: 100%; //needed because width declaration above this one supercedes normal .alignwide class unless the !important flag is used
@@ -263,7 +263,7 @@ p.has-background {
 
 	> .wrap {
 		@include center-wrap($entry-footer-wrap-max-width);
-		@include layout-wrap($layout-spacer-x);
+		@include layout-wrap();
 		display: flex;
 		flex-wrap: wrap;
 		align-items: $entry-footer-wrap-align-items;

--- a/src/sass/site/_utility-bar.scss
+++ b/src/sass/site/_utility-bar.scss
@@ -3,7 +3,7 @@
 
 	> .wrap {
 		@include center-wrap($utility-bar-wrap-max-width);
-		@include layout-wrap($layout-spacer-x);
+		@include layout-wrap();
 		padding: $utility-bar-wrap-padding;
 		display: flex;
 		flex-wrap: wrap;

--- a/src/sass/site/_utility-bar.scss
+++ b/src/sass/site/_utility-bar.scss
@@ -2,10 +2,9 @@
 	background-color: $utility-bar-background-color;
 
 	> .wrap {
-		padding: $utility-bar-wrap-padding-y $utility-bar-wrap-padding-x;
-
 		@include center-wrap($utility-bar-wrap-max-width);
-
+		@include layout-wrap($layout-spacer-x);
+		padding: $utility-bar-wrap-padding;
 		display: flex;
 		flex-wrap: wrap;
 		align-items: $utility-bar-wrap-align-items;

--- a/src/sass/variables/_colors.scss
+++ b/src/sass/variables/_colors.scss
@@ -81,7 +81,7 @@ $header-background-color: rgba(255, 255, 255, 0.95) !default;
 // Footer Widgets
 $footer-widgets-color: inherit !default;
 $footer-widgets-link-color: inherit !default;
-$footer-widgets-background-color: $gray-200 !default;
+$footer-widgets-background-color: $gray-100 !default;
 
 // Footer
 $footer-color: $white !default;

--- a/src/sass/variables/_colors.scss
+++ b/src/sass/variables/_colors.scss
@@ -78,10 +78,15 @@ $utility-bar-link-hover-color: darken($utility-bar-link-color, 15) !default;
 // Header
 $header-background-color: rgba(255, 255, 255, 0.95) !default;
 
+// Footer Widgets
+$footer-widgets-color: inherit !default;
+$footer-widgets-link-color: inherit !default;
+$footer-widgets-background-color: $gray-400 !default;
+
 // Footer
-$footer-widgets-background-color: $gray-100 !default;
-$footer-color: inherit !default;
-$footer-background-color: $primary-support !default;
+$footer-color: $white !default;
+$footer-link-color: inherit !default;
+$footer-background-color: $gray-800 !default;
 
 // Inputs
 $input-color: #666 !default;

--- a/src/sass/variables/_colors.scss
+++ b/src/sass/variables/_colors.scss
@@ -81,7 +81,7 @@ $header-background-color: rgba(255, 255, 255, 0.95) !default;
 // Footer Widgets
 $footer-widgets-color: inherit !default;
 $footer-widgets-link-color: inherit !default;
-$footer-widgets-background-color: $gray-400 !default;
+$footer-widgets-background-color: $gray-200 !default;
 
 // Footer
 $footer-color: $white !default;

--- a/src/sass/variables/_custom-properties.scss
+++ b/src/sass/variables/_custom-properties.scss
@@ -8,6 +8,11 @@
 		--color-contrast-sm: #{shade($body-color, 6%)};
 		--color-contrast-md: #{shade($body-color, 25%)};
 	}
+
+	--layout-spacer-x: #{ $spacer };
+	@media screen and ( min-width: $breakpoint-xs ) {
+		--layout-spacer-x: #{ $spacer-lg };
+	}
 }
 
 body.admin-bar {

--- a/src/sass/variables/_custom-properties.scss
+++ b/src/sass/variables/_custom-properties.scss
@@ -4,12 +4,13 @@
 	--color: #{$body-color};
 	--color-contrast-sm: #{tint($body-color, 6%)};
 	--color-contrast-md: #{tint($body-color, 40%)};
+	--layout-spacer-x: #{ $spacer };
+
 	@if color-yiq($body-color) == $yiq-text-dark {
 		--color-contrast-sm: #{shade($body-color, 6%)};
 		--color-contrast-md: #{shade($body-color, 25%)};
 	}
 
-	--layout-spacer-x: #{ $spacer };
 	@media screen and ( min-width: $breakpoint-xs ) {
 		--layout-spacer-x: #{ $spacer-lg };
 	}

--- a/src/sass/variables/_navigation.scss
+++ b/src/sass/variables/_navigation.scss
@@ -6,7 +6,7 @@ $menu-font-size: $font-size-base !default;
 $menu-icon-size: $menu-font-size * 1.75 !default;
 $menu-container-max-width: $wrap-max-width !default;
 $menu-container-padding-x: 0 !default;
-$menu-container-padding-y: $spacer-sm !default;
+$menu-container-padding-y: 0 !default;
 $menu-link-padding: $spacer-sm !default;
 $menu-link-padding-x: $menu-link-padding !default;
 $menu-link-padding-y: $menu-link-padding !default;

--- a/src/sass/variables/_navigation.scss
+++ b/src/sass/variables/_navigation.scss
@@ -1,7 +1,7 @@
-// Menu Breakpoint
+// Menu - breakpoint
 $menu-breakpoint: $breakpoint-md !default;
 
-// Menu - Global
+// Menu - global
 $menu-font-size: $font-size-base !default;
 $menu-icon-size: $menu-font-size * 1.75 !default;
 $menu-container-max-width: $wrap-max-width !default;
@@ -11,21 +11,21 @@ $menu-link-padding-y: $menu-link-padding !default;
 $menu-justify-content: space-between !default;
 $menu-align-items: center !default;
 
-// Submenu - Global
+// Menu - submenu
 $menu-sub-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2) !default;
 $menu-sub-link-padding-x: $menu-link-padding-x !default;
 $menu-sub-link-padding-y: $menu-link-padding-y !default;
 $menu-sub-link-width: 200px !default;
 
-// Menu - Footer
+// Menu - footer
 $menu-footer-justify-content: center !default;
 
-// Menu - Toggle
+// Menu - toggle
 $menu-toggle-padding-x: $menu-link-padding-x !default;
 $menu-toggle-padding-y: $menu-link-padding-y !default;
 $menu-toggle-display: inline-block !default;
 
-// Menu - Drawer
+// Menu - drawer
 $menu-drawer-padding: $spacer-md !default;
 $menu-drawer-padding-x: $menu-drawer-padding !default;
 $menu-drawer-padding-y: $menu-drawer-padding !default;

--- a/src/sass/variables/_navigation.scss
+++ b/src/sass/variables/_navigation.scss
@@ -5,8 +5,6 @@ $menu-breakpoint: $breakpoint-md !default;
 $menu-font-size: $font-size-base !default;
 $menu-icon-size: $menu-font-size * 1.75 !default;
 $menu-container-max-width: $wrap-max-width !default;
-$menu-container-padding-x: 0 !default;
-$menu-container-padding-y: 0 !default;
 $menu-link-padding: $spacer-sm !default;
 $menu-link-padding-x: $menu-link-padding !default;
 $menu-link-padding-y: $menu-link-padding !default;

--- a/src/sass/variables/_site.scss
+++ b/src/sass/variables/_site.scss
@@ -1,3 +1,7 @@
+// Layout
+$layout-spacer-x: $spacer-lg !default;
+$layout-spacer-y: $spacer-md !default;
+
 // Paragraph
 $paragraph-margin-bottom: $spacer !default;
 
@@ -18,18 +22,17 @@ $sitewide-alert-font-weight: bold !default;
 
 // Utility bar
 $utility-bar-wrap-max-width: $wrap-max-width !default;
-$utility-bar-wrap-padding-x: $spacer-md !default;
+$utility-bar-wrap-padding-x: $layout-spacer-x !default;
 $utility-bar-wrap-padding-y: $spacer-xs !default;
 $utility-bar-wrap-align-items: center !default;
 $utility-bar-wrap-justify-content: space-between !default;
 
 // Header
 $header-wrap-display: grid !default;
-$header-wrap-grid-column-gap: $spacer-md !default;
+$header-wrap-column-gap: $spacer-lg !default;
 $header-wrap-max-width: $wrap-max-width !default;
-$header-wrap-padding: $spacer-md !default;
-$header-wrap-padding-x: $header-wrap-padding !default;
-$header-wrap-padding-y: $header-wrap-padding !default;
+$header-wrap-padding-x: $layout-spacer-x !default;
+$header-wrap-padding-y: $layout-spacer-y !default;
 $header-wrap-align-items: center !default;
 $header-wrap-justify-content: space-between !default;
 
@@ -53,7 +56,7 @@ $branding-text-align: center !default;
 $logo-max-height: 8rem !default;
 
 // Header - widgets
-$header-widgets-padding-x: $spacer-md !default;
+$header-widgets-padding-x: $layout-spacer-x !default;
 $header-widgets-padding-y: 0 !default;
 $header-widgets-display: flex !default;
 $header-widgets-justify-content: flex-end !default;
@@ -62,7 +65,7 @@ $header-widgets-flex-grow: 1 !default;
 $header-widgets-order: 5 !default;
 
 // Main Navigation
-$main-navigation-wrap-padding-x: $spacer-md !default;
+$main-navigation-wrap-padding-x: $layout-spacer-x !default;
 $main-navigation-wrap-padding-y: 0 !default;
 
 // Layout
@@ -79,7 +82,7 @@ $layout-sidebar-content-columns: $layout-sidebar-width $layout-content-width !de
 $layout-sidebar-content-sidebar-columns: $layout-sidebar-width $layout-content-width $layout-sidebar-width !default;
 
 // Content
-$content-padding-x: $spacer-md !default;
+$content-padding-x: $layout-spacer-x !default;
 
 // Content - site content
 $site-content-padding: 0 !default;
@@ -106,20 +109,20 @@ $sidebar-widget-padding-x: $sidebar-widget-padding !default;
 $sidebar-widget-padding-y: $sidebar-widget-padding !default;
 
 // Footer widgets
+$footer-widgets-wrap-column-gap: $spacer-lg !default;
 $footer-widgets-wrap-max-width: $wrap-max-width !default;
-$footer-widgets-wrap-padding: $spacer-md !default;
-$footer-widgets-wrap-padding-x: $footer-widgets-wrap-padding !default;
-$footer-widgets-wrap-padding-y: $footer-widgets-wrap-padding !default;
+$footer-widgets-wrap-padding-x: $layout-spacer-x !default;
+$footer-widgets-wrap-padding-y: $spacer-lg !default;
 $footer-widgets-wrap-align-items: flex-start !default;
 $footer-widgets-wrap-justify-content: space-between !default;
 $footer-widgets-widget-area-flex-basis: 0 !default;
 $footer-widgets-widget-area-flex-grow: 1 !default;
+$footer-widgets-widget-margin: 0 0 $spacer-md 0 !default;
 
 // Footer
 $footer-wrap-max-width: $wrap-max-width !default;
-$footer-wrap-padding: $spacer-md !default;
-$footer-wrap-padding-x: $footer-wrap-padding !default;
-$footer-wrap-padding-y: $footer-wrap-padding !default;
+$footer-wrap-padding-x: $layout-spacer-x !default;
+$footer-wrap-padding-y: $layout-spacer-y !default;
 $footer-wrap-align-items: flex-start !default;
 $footer-wrap-justify-content: center !default;
 $footer-wrap-flex-wrap: wrap !default;

--- a/src/sass/variables/_site.scss
+++ b/src/sass/variables/_site.scss
@@ -104,8 +104,7 @@ $sidebar-widget-padding-y: $sidebar-widget-padding !default;
 // Footer widgets
 $footer-widgets-wrap-column-gap: $spacer-lg !default;
 $footer-widgets-wrap-max-width: $wrap-max-width !default;
-$footer-widgets-wrap-padding-x: $layout-spacer-x !default;
-$footer-widgets-wrap-padding-y: $spacer-lg !default;
+$footer-widgets-wrap-padding: $spacer-lg 0 !default;
 $footer-widgets-wrap-align-items: flex-start !default;
 $footer-widgets-wrap-justify-content: space-between !default;
 $footer-widgets-widget-area-flex-basis: 0 !default;

--- a/src/sass/variables/_site.scss
+++ b/src/sass/variables/_site.scss
@@ -22,8 +22,7 @@ $sitewide-alert-font-weight: bold !default;
 
 // Utility bar
 $utility-bar-wrap-max-width: $wrap-max-width !default;
-$utility-bar-wrap-padding-x: $layout-spacer-x !default;
-$utility-bar-wrap-padding-y: $spacer-xs !default;
+$utility-bar-wrap-padding: $spacer-xs 0 !default;
 $utility-bar-wrap-align-items: center !default;
 $utility-bar-wrap-justify-content: space-between !default;
 
@@ -31,8 +30,7 @@ $utility-bar-wrap-justify-content: space-between !default;
 $header-wrap-display: grid !default;
 $header-wrap-column-gap: $spacer-lg !default;
 $header-wrap-max-width: $wrap-max-width !default;
-$header-wrap-padding-x: $layout-spacer-x !default;
-$header-wrap-padding-y: $layout-spacer-y !default;
+$header-wrap-padding: $layout-spacer-y 0 !default;
 $header-wrap-align-items: center !default;
 $header-wrap-justify-content: space-between !default;
 
@@ -64,9 +62,8 @@ $header-widgets-flex-wrap: wrap !default;
 $header-widgets-flex-grow: 1 !default;
 $header-widgets-order: 5 !default;
 
-// Main Navigation
-$main-navigation-wrap-padding-x: $layout-spacer-x !default;
-$main-navigation-wrap-padding-y: 0 !default;
+// Menu - main navigation
+$main-navigation-wrap-padding: $spacer-sm 0 !default;
 
 // Layout
 $layout-breakpoint-sm: $breakpoint-sm !default;
@@ -80,14 +77,6 @@ $layout-content-columns: 1fr !default;
 $layout-content-sidebar-columns: $layout-content-width $layout-sidebar-width !default;
 $layout-sidebar-content-columns: $layout-sidebar-width $layout-content-width !default;
 $layout-sidebar-content-sidebar-columns: $layout-sidebar-width $layout-content-width $layout-sidebar-width !default;
-
-// Content
-$content-padding-x: $layout-spacer-x !default;
-
-// Content - site content
-$site-content-padding: 0 !default;
-$site-content-padding-x: $site-content-padding !default;
-$site-content-padding-y: $site-content-padding !default;
 
 // Content - entry header
 $entry-header-wrap-max-width: $wrap-max-width !default;

--- a/src/sass/variables/_site.scss
+++ b/src/sass/variables/_site.scss
@@ -95,13 +95,17 @@ $entry-header-wrap-max-width: $wrap-max-width !default;
 // Content - nav links (pagination)
 $nav-links-max-width: $wrap-max-width !default;
 
-// Content - comments
-$comments-area-wrap-max-width: $content-max-width !default;
-
 // Content - entry footer
 $entry-footer-wrap-max-width: $content-max-width !default;
 $entry-footer-wrap-align-items: center !default;
 $entry-footer-wrap-justify-content: space-between !default;
+
+// Content - comments (comments area)
+$comments-area-wrap-max-width: $content-max-width !default;
+
+// Content - comment (individual comment)
+$comment-border: 0 solid $gray-300 !default;
+$comment-border-width: 0 0 0 5px !default;
 
 // Sidebar - widget
 $sidebar-widget-padding: $spacer-md !default;

--- a/src/sass/variables/_woocommerce.scss
+++ b/src/sass/variables/_woocommerce.scss
@@ -20,7 +20,7 @@ $wc-shop-product-min-width-lg: 300px !default;
 $wc-max-width: $breakpoint-lg !default;
 
 // Archives
-$wc-archive-padding-x: $content-padding-x !default;
+$wc-archive-padding-x: $layout-spacer-x !default;
 $wc-archive-column-gap: $wc-gap !default;
 $wc-archive-row-gap: $wc-gap !default;
 

--- a/src/sass/woocommerce/_base.scss
+++ b/src/sass/woocommerce/_base.scss
@@ -3,8 +3,8 @@
 		> * {
 			margin: $spacer-lg auto;
 			max-width: $wc-max-width;
-			padding-left: $content-padding-x;
-			padding-right: $content-padding-x;
+			padding-left: $layout-spacer-x;
+			padding-right: $layout-spacer-x;
 		}
 	}
 }

--- a/src/sass/woocommerce/components/_alerts.scss
+++ b/src/sass/woocommerce/components/_alerts.scss
@@ -59,7 +59,7 @@
 
 		@media screen and (min-width: $breakpoint-sm) {
 			grid-template-columns: 1fr auto;
-			grid-column-gap: $spacer-sm;
+			column-gap: $spacer-sm;
 
 			*,
 			.button {

--- a/src/sass/woocommerce/layouts/_checkout.scss
+++ b/src/sass/woocommerce/layouts/_checkout.scss
@@ -58,7 +58,7 @@
 
 			@media screen and (min-width: $breakpoint-md) {
 				grid-template-columns: 1fr 1fr;
-				grid-column-gap: $spacer-lg;
+				column-gap: $spacer-lg;
 			}
 		}
 
@@ -76,7 +76,7 @@
 
 			@media screen and (min-width: $breakpoint-sm) {
 				grid-template-columns: 1fr 1fr;
-				grid-column-gap: $spacer;
+				column-gap: $spacer;
 
 				.form-row {
 					grid-column: 1 / 3;

--- a/src/sass/woocommerce/layouts/_my-account.scss
+++ b/src/sass/woocommerce/layouts/_my-account.scss
@@ -16,7 +16,7 @@
 
 					@media screen and (min-width: $breakpoint-sm) {
 						grid-template-columns: auto 1fr;
-						grid-column-gap: $spacer-xl;
+						column-gap: $spacer-xl;
 					}
 				}
 			}
@@ -48,7 +48,7 @@
 
 			@media screen and (min-width: $breakpoint-md) {
 				grid-template-columns: 1fr 1fr;
-				grid-column-gap: $spacer-xl;
+				column-gap: $spacer-xl;
 			}
 		}
 

--- a/src/sass/woocommerce/layouts/_order-received.scss
+++ b/src/sass/woocommerce/layouts/_order-received.scss
@@ -26,7 +26,7 @@ table.woocommerce-table--order-details {
 
 		@media screen and (min-width: $breakpoint-sm) {
 			grid-template-columns: 1fr 1fr;
-			grid-column-gap: $spacer-xl;
+			column-gap: $spacer-xl;
 		}
 	}
 

--- a/src/sass/woocommerce/layouts/_single-product.scss
+++ b/src/sass/woocommerce/layouts/_single-product.scss
@@ -170,12 +170,12 @@
 				.comment_container {
 					display: grid;
 					grid-template-columns: 50px 1fr;
-					grid-column-gap: $spacer-sm;
+					column-gap: $spacer-sm;
 					margin: $spacer-sm 0;
 
 					@media screen and (min-width: $breakpoint-sm) {
 						grid-template-columns: 70px 1fr;
-						grid-column-gap: $spacer;
+						column-gap: $spacer;
 					}
 
 					.star-rating {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/pressden/emma
 Author: D.S. Webster | Eric Michel
 Author URI: https://github.com/pressden/emma
 Description: Emma is a highly customizable parent theme powered by NPM, Webpack, SASS and ES6.
-Version: 1.0.21
+Version: 1.0.22
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: emma

--- a/template-parts/footer-widgets.php
+++ b/template-parts/footer-widgets.php
@@ -1,15 +1,23 @@
 <?php
-if (
-	is_active_sidebar( 'footer-widgets-1' ) ||
-	is_active_sidebar( 'footer-widgets-2' ) ||
-	is_active_sidebar( 'footer-widgets-3' ) ) {
+// Disable footer widgets by default.
+$show_footer_widgets = false;
+
+// Enable footer widgets if any of the widget areas are active.
+for ( $i = 1; $i <= $GLOBALS['emma_footer_widget_areas']; $i++ ) {
+	if ( is_active_sidebar( 'footer-widgets-' . $i ) ) {
+		$show_footer_widgets = true;
+	}
+}
+
+// Conditionally render the footer widgets.
+if ( $show_footer_widgets ) {
 	?>
 
 	<aside id="back-matter" class="footer-widgets">
 		<div class="wrap">
 
 			<?php
-			for ( $i = 1; $i <= 3; $i++ ) {
+			for ( $i = 1; $i <= $GLOBALS['emma_footer_widget_areas']; $i++ ) {
 				if ( is_active_sidebar( 'footer-widgets-' . $i ) ) {
 					?>
 

--- a/template-parts/site-info.php
+++ b/template-parts/site-info.php
@@ -1,6 +1,6 @@
 <div class="site-info">
 	&copy;<?php echo date( 'Y' ); ?>
-	<a href="<?php echo home_url(); ?>"><?php esc_html( get_bloginfo( 'name' ) ); ?></a>
+	<a href="<?php echo home_url(); ?>"><?php echo esc_html( get_bloginfo( 'name' ) ); ?></a>
 	<span class="sep"> | </span>
 	<?php esc_html_e( 'All rights reserved.', 'emma' ); ?>
 </div><!-- .site-info -->

--- a/template-parts/site-info.php
+++ b/template-parts/site-info.php
@@ -1,5 +1,5 @@
 <div class="site-info">
-	&copy;<?php echo date( 'Y' ); ?>
+	Copyright &copy; <?php echo date( 'Y' ); ?>
 	<a href="<?php echo home_url(); ?>"><?php echo esc_html( get_bloginfo( 'name' ) ); ?></a>
 	<span class="sep"> | </span>
 	<?php esc_html_e( 'All rights reserved.', 'emma' ); ?>


### PR DESCRIPTION
This update touches a variety of layout related styles including outer gutters, column-gaps, footer widgets, comments, background-colors, etc.

The end goal is to tidy up the Emma defaults so it looks a little more polished and ready to go right out of the box.

Some of these changes are opinion based. As an example, the site layout was previously styled to have `1rem` (16px) outer margins on the left and right side of the content. This felt very close to the edge. Now it's doubled to `2rem` (32px) and feels much more polished.

The before and after screenshots should help to visualize some of these subtle changes.

<img width="1600" alt="header-body-comments" src="https://user-images.githubusercontent.com/9062957/124596847-bddb6280-de30-11eb-8b62-69d56f950473.png">

<img width="1601" alt="footer" src="https://user-images.githubusercontent.com/9062957/124598592-ca60ba80-de32-11eb-8a79-a063ab2a4927.png">
