### PR TITLE
unified pagination and improved icon CSS

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -53,6 +53,9 @@ if ( class_exists( 'WooCommerce' ) ) {
 
 	// Filter title visibility on Woocommerce pages.
 	add_filter( 'woocommerce_show_page_title', 'emma_woocommerce_show_page_title' );
+
+	remove_action('woocommerce_after_shop_loop', 'woocommerce_pagination', 10);
+	add_action( 'woocommerce_after_shop_loop', 'emma_pagination', 10);
 }
 
 /**

--- a/src/sass/navigation/_pagination.scss
+++ b/src/sass/navigation/_pagination.scss
@@ -36,18 +36,16 @@
 	.next,
 	.prev {
 		position: relative;
-		width: 3rem;
-	}
+		width: 2.5rem;
 
-	.prev {
 		&::before {
-			@include icon-mask( 'arrow-left-alt' );
+			@include icon-mask( 'arrow-left-alt2' );
 		}
 	}
 
 	.next {
 		&::before {
-			@include icon-mask( 'arrow-right-alt' );
+			transform: rotate( 180deg );
 		}
 	}
 


### PR DESCRIPTION
unhooked woocommerce-specific pagination and hooked in our own so it matches blog archives, changed icons to use a single left arrow that is rotated to make the right arrow (loading in fewer SVGs)