### PR TITLE
Add gap helpers

### DIFF
--- a/src/sass/gutenberg/blocks/_wp-block-columns.scss
+++ b/src/sass/gutenberg/blocks/_wp-block-columns.scss
@@ -24,7 +24,7 @@ $full-columns-breakpoint: 782px;
 
 	&.cg-0 {
 		column-gap: 0;
-	
+
 		.wp-block-column {
 			@media screen and (min-width: $two-columns-breakpoint) and (max-width: $full-columns-breakpoint - 1px) {
 				//max-width is required for inline flex-basis to work
@@ -35,7 +35,7 @@ $full-columns-breakpoint: 782px;
 
 	&.cg-sm {
 		column-gap: $spacer;
-	
+
 		@media screen and (min-width: $two-columns-breakpoint) and (max-width: $full-columns-breakpoint - 1px) {
 			.wp-block-column {
 				flex-basis: calc(50% - #{$spacer} / 2) !important;

--- a/src/sass/modules/_utilities.scss
+++ b/src/sass/modules/_utilities.scss
@@ -179,3 +179,16 @@ $border-locations: (
 		border-color: $color;
 	}
 }
+
+// Gap utilities (based on spacer sizes)
+@each $name, $gap in $spacer-sizes {
+	.cg-#{$name} {
+		column-gap: $gap;
+	}
+}
+
+@each $name, $gap in $spacer-sizes {
+	.rg-#{$name} {
+		row-gap: $gap;
+	}
+}

--- a/src/sass/variables/_utilities.scss
+++ b/src/sass/variables/_utilities.scss
@@ -21,7 +21,7 @@ $spacer-sizes: (
 	"md": $spacer-md,
 	"lg": $spacer-lg,
 	"xl": $spacer-xl,
-);
+) !default;
 
 // Responsive Font Sizes
 $enable-responsive-font-sizes: true !default;


### PR DESCRIPTION
With the switch to universal `column-gap` and `row-gap` it makes sense to have Gutenberg friendly helpers that match our $spacer helpers.

Examples:
`.cg-0`
`.cg-lg`
`.rg-0`
`.rg-xl`

Before we can merge this in though we need to resolve the conflicting definitions in this file:
`/src/sass/gutenberg/blocks/_wp-block-columns.scss`

That file has hardcoded references to `.rg-0`, `.rg-lg`, `.cg-0` and `.cg-sm`. I believe you originally wrote those styles so I don't want to make any assumptions about their purpose, especially the baked in media queries.