### PR TITLE
Feature/widget blocks

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -304,15 +304,23 @@ function emma_widgets_init() {
 	}
 
 	// Filter 'emma_footer_widget_areas' in the global scope for use in templates.
-	$GLOBALS['emma_footer_widget_areas'] = apply_filters( 'emma_footer_widget_areas', 3 );
+	$GLOBALS['emma_footer_widget_areas'] = apply_filters( 'emma_footer_widget_areas', 1 );
 
 	// Add the footer widgets areas.
-	for ( $i = 1; $i <= $GLOBALS['emma_footer_widget_areas']; $i++ ) {
-		$widget_areas[ 'footer-widgets-' . $i ] = array(
-			'name'        => esc_html__( 'Footer Widgets', 'emma' ) . " $i",
-			'id'          => 'footer-widgets-' . $i,
-			'description' => esc_html__( 'Add widgets above the site footer', 'emma' ) . ' (' . esc_html__( 'column', 'emma' ) . " $i).",
+	if( $GLOBALS['emma_footer_widget_areas'] == 1 ) {
+		$widget_areas[ 'footer-widgets' ] = array(
+			'name'        => esc_html__( 'Footer Widgets', 'emma' ),
+			'id'          => 'footer-widgets',
+			'description' => esc_html__( 'Add widgets above the site footer', 'emma' ),
 		);
+	} else {
+		for ( $i = 1; $i <= $GLOBALS['emma_footer_widget_areas']; $i++ ) {
+			$widget_areas[ 'footer-widgets-' . $i ] = array(
+				'name'        => esc_html__( 'Footer Widgets', 'emma' ) . " $i",
+				'id'          => 'footer-widgets-' . $i,
+				'description' => esc_html__( 'Add widgets above the site footer', 'emma' ) . ' (' . esc_html__( 'column', 'emma' ) . " $i).",
+			);
+		}
 	}
 
 	// Filter $widget_areas.

--- a/src/sass/site/_posts-and-pages.scss
+++ b/src/sass/site/_posts-and-pages.scss
@@ -80,6 +80,7 @@
 
 .entry-content,
 .page-content,
+.widget_block,
 .wp-block-cover__inner-container,
 .wp-block-group__inner-container,
 .wp-block-column {
@@ -92,6 +93,7 @@
 
 .entry-content,
 .page-content,
+.widget_block,
 .wp-block-cover__inner-container {
 	> * {
 		@include layout-wrap();
@@ -230,6 +232,7 @@
 }
 
 .entry-content,
+.widget_block,
 .wp-block-cover__inner-container,
 .wp-block-group__inner-container {
 	> * {

--- a/template-parts/footer-widgets.php
+++ b/template-parts/footer-widgets.php
@@ -2,36 +2,46 @@
 // Disable footer widgets by default.
 $show_footer_widgets = false;
 
-// Enable footer widgets if any of the widget areas are active.
-for ( $i = 1; $i <= $GLOBALS['emma_footer_widget_areas']; $i++ ) {
-	if ( is_active_sidebar( 'footer-widgets-' . $i ) ) {
-		$show_footer_widgets = true;
-	}
-}
-
-// Conditionally render the footer widgets.
-if ( $show_footer_widgets ) {
+if( $GLOBALS['emma_footer_widget_areas'] == 1 ) {
+	if( is_active_sidebar( 'footer-widgets' ) ) {
 	?>
-
-	<aside id="back-matter" class="footer-widgets">
-		<div class="wrap">
-
-			<?php
-			for ( $i = 1; $i <= $GLOBALS['emma_footer_widget_areas']; $i++ ) {
-				if ( is_active_sidebar( 'footer-widgets-' . $i ) ) {
-					?>
-
-					<section class="footer-widgets-<?php echo $i; ?> widget-area">
-						<?php dynamic_sidebar( 'footer-widgets-' . $i ); ?>
-					</section>
-
-					<?php
-				}
-			}
-			?>
-
-		</div><!-- .wrap -->
-	</aside><!-- #back-matter -->
-
+		<aside id="back-matter" class="footer-widgets">
+			<?php dynamic_sidebar( 'footer-widgets' ); ?>
+		</aside>
 	<?php
+	}
+} else {
+	// Enable footer widgets if any of the widget areas are active.
+	for ( $i = 1; $i <= $GLOBALS['emma_footer_widget_areas']; $i++ ) {
+		if ( is_active_sidebar( 'footer-widgets-' . $i ) ) {
+			$show_footer_widgets = true;
+		}
+	}
+
+	// Conditionally render the footer widgets.
+	if ( $show_footer_widgets ) {
+		?>
+
+		<aside id="back-matter" class="footer-widgets">
+			<div class="wrap">
+
+				<?php
+				for ( $i = 1; $i <= $GLOBALS['emma_footer_widget_areas']; $i++ ) {
+					if ( is_active_sidebar( 'footer-widgets-' . $i ) ) {
+						?>
+
+						<section class="footer-widgets-<?php echo $i; ?> widget-area">
+							<?php dynamic_sidebar( 'footer-widgets-' . $i ); ?>
+						</section>
+
+						<?php
+					}
+				}
+				?>
+
+			</div><!-- .wrap -->
+		</aside><!-- #back-matter -->
+
+		<?php
+	}
 }


### PR DESCRIPTION
@dswebsme I purposefully left out any top/bottom padding on the `footer-widgets` container so that a group block can be used to change, for instance, background color. I know we have a background color SASS variable for the footer, but I almost always change it and have to look up the variable, so being able to drop in a group block and just assign a color via the GUI is really nice.

This ends up making straight up paragraph blocks in that widget area showing as flush against the top. Utility classes like `mt-lg` will take care of that.

Let me know if you're comfortable with this.