### PR TITLE
fixed JS that was causing SVGs to receive focus on tab

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -134,19 +134,19 @@ function emma_add_product_sorting_column_sizer() {
 		<li class='woocommerce-columns-sizer columns-1 <?php echo ( 1 === $columns ) ? 'active' : ''; ?>'>
 			<a href='#' data-size="columns-1">
 				<span class="screen-reader-text">Make Columns Small Size</span>
-				<svg xmlns="http://www.w3.org/2000/svg" tabindex=-1 preserveAspectRatio="xMidYMin meet" viewBox="0 0 24 24"><rect tabindex=-1 x="18" y="9" width="6" height="6"/><rect tabindex=-1 x="18" y="18" width="6" height="6"/><rect tabindex=-1 x="9" y="18" width="6" height="6"/><rect tabindex=-1 y="18" width="6" height="6"/><rect tabindex=-1 x="9" y="9" width="6" height="6"/><rect tabindex=-1 y="9" width="6" height="6"/><rect tabindex=-1 x="9" width="6" height="6"/><rect tabindex=-1 width="6" height="6"/><rect tabindex=-1 x="18" width="6" height="6"/></svg>
+				<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMin meet" viewBox="0 0 24 24"><rect x="18" y="9" width="6" height="6"/><rect x="18" y="18" width="6" height="6"/><rect x="9" y="18" width="6" height="6"/><rect y="18" width="6" height="6"/><rect x="9" y="9" width="6" height="6"/><rect y="9" width="6" height="6"/><rect x="9" width="6" height="6"/><rect width="6" height="6"/><rect x="18" width="6" height="6"/></svg>
 			</a>
 		</li>
 		<li class='woocommerce-columns-sizer columns-2 <?php echo ( 2 === $columns ) ? 'active' : ''; ?>'>
 			<a href='#' data-size="columns-2">
 				<span class="screen-reader-text">Make Columns Medium Size</span>
-				<svg xmlns="http://www.w3.org/2000/svg" tabindex=-1 preserveAspectRatio="xMidYMin meet" viewBox="0 0 24 24"><rect tabindex=-1 width="10" height="10"/><rect tabindex=-1 x="14" width="10" height="10"/><rect tabindex=-1 x="14" y="14" width="10" height="10"/><rect tabindex=-1 y="14" width="10" height="10"/></svg>
+				<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMin meet" viewBox="0 0 24 24"><rect width="10" height="10"/><rect x="14" width="10" height="10"/><rect x="14" y="14" width="10" height="10"/><rect y="14" width="10" height="10"/></svg>
 			</a>
 		</li>
 		<li class='woocommerce-columns-sizer columns-3 <?php echo ( 3 === $columns ) ? 'active' : ''; ?>'>
 			<a href='#' data-size="columns-3">
 				<span class="screen-reader-text">Make Columns Large Size</span>
-				<svg xmlns="http://www.w3.org/2000/svg" tabindex=-1 preserveAspectRatio="xMidYMin meet" viewBox="0 0 24 24"><rect tabindex=-1 width="24" height="24"/></svg>
+				<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMin meet" viewBox="0 0 24 24"><rect width="24" height="24"/></svg>
 			</a>
 		</li>
 	</ul>

--- a/src/js/woocommerce.js
+++ b/src/js/woocommerce.js
@@ -103,14 +103,15 @@ $(function () {
 		}
 	});
 
-	$("*").focus(function () {
+	document.addEventListener( 'focus', function() {
+		let newFocus = document.activeElement;
 		if (
-			!$(this).hasClass(".mini-cart-toggle") &&
-			!$(this).closest("#mini-cart").length
+			!$(newFocus).hasClass(".mini-cart-toggle") &&
+			!$(newFocus).closest("#mini-cart").length
 		) {
 			hideMiniCart();
 		}
-	});
+	}, true );
 });
 
 function relocateMiniCart($miniCart) {


### PR DESCRIPTION
Solves #223

SVG elements are not focusable by default. In Chrome and Edge, when a `focus` event handler is added to an SVG element, it becomes focusable. This jQuery selector: `$("*").focus(function () {` was causing SVG elements to be focusable.

Back when I originally worked on the WooCommerce implementation in `emma`, I didn't realize focusable SVG elements wasn't default behavior, so I had an unintended workaround in `woocommerce.php` I was also able to remove as part of this PR.

To test, copy the following SVG code into an `html` block in an `emma` site on the `prod` branch with WooCommerce installed and active:
```
<svg height="400" width="450">
<path id="lineAB" d="M 100 350 l 150 -300" stroke="red" stroke-width="3" fill="none" />
  <path id="lineBC" d="M 250 50 l 150 300" stroke="red" stroke-width="3" fill="none" />
  <path d="M 175 200 l 150 0" stroke="green" stroke-width="3" fill="none" />
  <path d="M 100 350 q 150 -300 300 0" stroke="blue" stroke-width="5" fill="none" />
  <!-- Mark relevant points -->
  <g stroke="black" stroke-width="3" fill="black">
    <circle id="pointA" cx="100" cy="350" r="3" />
    <circle id="pointB" cx="250" cy="50" r="3" />
    <circle id="pointC" cx="400" cy="350" r="3" />
  </g>
  <!-- Label the points -->
  <g font-size="30" font-family="sans-serif" fill="black" stroke="none" text-anchor="middle">
    <text x="100" y="350" dx="-30">A</text>
    <text x="250" y="50" dy="-10">B</text>
    <text x="400" y="350" dx="30">C</text>
  </g>
  Sorry, your browser does not support inline SVG.
</svg>
```

You should find that all elements in the SVG are focusable. For instance, the `B` here:
![image](https://user-images.githubusercontent.com/45110062/166559356-dfe4df43-b520-436b-a547-5dde40dba117.png)

After updating to this branch, no elements of the SVG should be focusable.